### PR TITLE
Update contexts.py argument in _xams_xasml_context function for xams

### DIFF
--- a/amstrax/contexts.py
+++ b/amstrax/contexts.py
@@ -50,7 +50,7 @@ def xams(*args, **kwargs):
                         runid_field='number',
                         mongo_dbname='run',
                         )
-    st = _xams_xamsl_context(*args, **kwargs, _detector='xamsl', mongo_kwargs=mongo_kwargs)
+    st = _xams_xamsl_context(*args, **kwargs, _detector='xams', mongo_kwargs=mongo_kwargs)
     st.set_config(xams_common_config)
     return st
 


### PR DESCRIPTION
My first PR! Shouldn't it be 'xams' as _detector argument in the  _xams_xasml_context function (or just leave it out since it was already set as default)?