### PR TITLE
TEMPORARY change from runs_gas to runs_new in xams context

### DIFF
--- a/amstrax/contexts.py
+++ b/amstrax/contexts.py
@@ -46,7 +46,7 @@ xams_common_config = dict(
 def xams(*args, **kwargs):
     if '_detector' in kwargs:
         raise ValueError('Don\'t specifify _detector!')
-    mongo_kwargs = dict(mongo_collname='runs_gas',
+    mongo_kwargs = dict(mongo_collname='runs_new',
                         runid_field='number',
                         mongo_dbname='run',
                         )


### PR DESCRIPTION
Will change this back (or to new runs collection name for xams) as soon as I looked into the data.