### PR TITLE
IMPORTANT: (hardcoded) change in get_mongo_collection function 

### DIFF
--- a/amstrax/auto_processing/amstraxer.py
+++ b/amstrax/auto_processing/amstraxer.py
@@ -120,7 +120,8 @@ def main(args):
             testing_rd['start'] = datetime.datetime.now()
         st = amstrax.contexts.context_for_daq_reader(st,
                                                      args.run_id,
-                                                     run_doc=testing_rd)
+                                                     run_doc=testing_rd,
+                                                     detector=args.detector)
 
     if args.from_scratch:
         for q in st.storage:

--- a/amstrax/auto_processing/auto_processing.py
+++ b/amstrax/auto_processing/auto_processing.py
@@ -46,7 +46,7 @@ if __name__ == '__main__':
     context = args.context
     detector = args.detector
     target = args.target
-    runs_col = amstrax.get_mongo_collection()
+    runs_col = amstrax.get_mongo_collection(detector)
 
     while 1:
         # Update task list

--- a/amstrax/auto_processing/copy_live.py
+++ b/amstrax/auto_processing/copy_live.py
@@ -174,7 +174,7 @@ def main(args):
     # Initialize runsdatabase collection
     runs_database = config['RunsDatabaseName']
     runs_collection = config['RunsDatabaseCollection']
-    runsdb = amstrax.get_mongo_collection(
+    runsdb = amstrax.get_mongo_collection(detector,
         database_name=runs_database,
         database_col=runs_collection
     )

--- a/amstrax/auto_processing/process_run.py
+++ b/amstrax/auto_processing/process_run.py
@@ -6,7 +6,8 @@ if __name__ == '__main__':
     # Do import later to get fast --help
     import amstrax
 
-    run_collection = amstrax.get_mongo_collection()
+    detector = args.detector
+    run_collection = amstrax.get_mongo_collection(detector)
     run_name = args.run_id
     target = args.target
     print(f'Start processing {run_name}: {target}')

--- a/amstrax/contexts.py
+++ b/amstrax/contexts.py
@@ -46,7 +46,7 @@ xams_common_config = dict(
 def xams(*args, **kwargs):
     if '_detector' in kwargs:
         raise ValueError('Don\'t specifify _detector!')
-    mongo_kwargs = dict(mongo_collname='runs_gas',
+    mongo_kwargs = dict(mongo_collname='runs_gas', #IF YOU CHANGE THIS, ALSO CHANGE IN GET_MONGO_COLLECTION (RUNSDB.PY)!
                         runid_field='number',
                         mongo_dbname='run',
                         )
@@ -175,6 +175,7 @@ def amstrax_run10_analysis(output_folder='./strax_data'):
 
 def context_for_daq_reader(st: strax.Context,
                            run_id: str,
+                           detector: str,
                            runs_col_kwargs: dict = None,
                            run_doc: dict = None,
                            check_exists=True,
@@ -204,7 +205,7 @@ def context_for_daq_reader(st: strax.Context,
     if runs_col_kwargs is None:
         runs_col_kwargs = {}
     if run_doc is None:
-        run_col = ax.get_mongo_collection(**runs_col_kwargs)
+        run_col = ax.get_mongo_collection(detector)
         run_doc = run_col.find_one({'number': int(run_id)})
     daq_config = run_doc['daq_config']
     live_dir = st.config['live_data_dir']

--- a/amstrax/rundb.py
+++ b/amstrax/rundb.py
@@ -72,7 +72,7 @@ def get_mongo_collection(detector,
     elif detector == 'xamsl':
         return get_mongo_client(**link_kwargs)['run']['runs_new']
     else:
-        print(f'NameError: detector {detector} is not a valid detector name.')
+        raise NameError(f'detector {detector} is not a valid detector name.')
 
 @export
 class RunDB(strax.StorageFrontend):

--- a/amstrax/rundb.py
+++ b/amstrax/rundb.py
@@ -55,14 +55,24 @@ def get_mongo_client(**link_kwargs):
     return pymongo.MongoClient(f'mongodb://{user}:{password}@127.0.0.1:{local_port}/admin')
 
 
+# @export
+# def get_mongo_collection(database_name='run',
+#                          database_col='runs_new',
+#                          **link_kwargs,
+#                          ):
+#     """Get the runs collection"""
+#     return get_mongo_client(**link_kwargs)[database_name][database_col]
+
 @export
-def get_mongo_collection(database_name='run',
-                         database_col='runs_new',
+def get_mongo_collection(detector,
                          **link_kwargs,
                          ):
-    """Get the runs collection"""
-    return get_mongo_client(**link_kwargs)[database_name][database_col]
-
+    if detector == 'xams':
+        return get_mongo_client(**link_kwargs)['run']['runs_gas']
+    elif detector == 'xamsl':
+        return get_mongo_client(**link_kwargs)['run']['runs_new']
+    else:
+        print(f'NameError: detector {detector} is not a valid detector name.')
 
 @export
 class RunDB(strax.StorageFrontend):

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -34,7 +34,8 @@ class TestXamsStack(unittest.TestCase):
         st = amstrax.contexts.context_for_daq_reader(
             self.st,
             run_id=self.run_id,
-            run_doc=self.rd)
+            run_doc=self.rd,
+            detector='xams')
         self.st = st
 
     @classmethod
@@ -61,7 +62,8 @@ class TestXamsStack(unittest.TestCase):
             amstrax.contexts.context_for_daq_reader(
                 self.st,
                 run_id=self.run_id,
-                run_doc=self.rd)
+                run_doc=self.rd,
+                detector='xams')
 
     def get_metadata(self):
         md = amstrax_files.get_file(self.run_doc_name)


### PR DESCRIPTION
IMPORTANT: (hardcoded) change in get_mongo_collection function and implementation every time `get_mongo_collection` is called! This should now work properly as long as you give `--detector` as a flag to your favorite processing script (should we make this a required argument?).