### PR TITLE
Inprove copy live: only copy data if run has finished (ignore ugly PR #112)

### DIFF
--- a/amstrax/auto_processing/copy_live.py
+++ b/amstrax/auto_processing/copy_live.py
@@ -121,7 +121,7 @@ def exec_commands_and_cleanup(runsdb: pymongo.collection.Collection,
             logs.debug(f'Nothing to transfer for {run}')
             continue
 
-        # Only copy the data if the run has finished
+        # Only copy the data if the run has finished and there is actually data
         if 'THE_END' in os.listdir(f'{location}/{run:06d}'):
             cmd = f'rsync -a {location}/{run:06d} -e ssh stbc:{target_location}'
             logs.warning(f'Do {cmd} for {run}')

--- a/amstrax/auto_processing/copy_live.py
+++ b/amstrax/auto_processing/copy_live.py
@@ -174,8 +174,6 @@ def main(args):
     dest_loc = config['dest_location']
 
     # Initialize runsdatabase collection
-    runs_database = config['RunsDatabaseName']
-    runs_collection = config['RunsDatabaseCollection']
     runsdb = amstrax.get_mongo_collection(detector)
 
     # Make a list of the last 'max_runs' items in the runs database, 

--- a/amstrax/auto_processing/copy_live.py
+++ b/amstrax/auto_processing/copy_live.py
@@ -176,10 +176,7 @@ def main(args):
     # Initialize runsdatabase collection
     runs_database = config['RunsDatabaseName']
     runs_collection = config['RunsDatabaseCollection']
-    runsdb = amstrax.get_mongo_collection(detector,
-        database_name=runs_database,
-        database_col=runs_collection
-    )
+    runsdb = amstrax.get_mongo_collection(detector)
 
     # Make a list of the last 'max_runs' items in the runs database, 
     # only keeping the fields 'number', 'data' and '_id'.

--- a/amstrax/auto_processing/copy_live.py
+++ b/amstrax/auto_processing/copy_live.py
@@ -121,10 +121,12 @@ def exec_commands_and_cleanup(runsdb: pymongo.collection.Collection,
             logs.debug(f'Nothing to transfer for {run}')
             continue
 
-        cmd = f'rsync -a {location}/{run:06d} -e ssh stbc:{target_location}'
-        logs.warning(f'Do {cmd} for {run}')
-        # disable bandit
-        copy_execute = subprocess.call(cmd, shell=True)
+        # Only copy the data if the run has finished
+        if 'THE_END' in os.listdir(f'{location}/{run:06d}'):
+            cmd = f'rsync -a {location}/{run:06d} -e ssh stbc:{target_location}'
+            logs.warning(f'Do {cmd} for {run}')
+            # disable bandit
+            copy_execute = subprocess.call(cmd, shell=True)
 
         # If copying was successful, update the runsdatabase
         # with the new location of the data

--- a/amstrax/auto_processing/copy_live.py
+++ b/amstrax/auto_processing/copy_live.py
@@ -179,7 +179,7 @@ def main(args):
     # Make a list of the last 'max_runs' items in the runs database, 
     # only keeping the fields 'number', 'data' and '_id'.
     # pylint: disable=fixme
-    query = {}  # TODO for now, but we should query on the data field in the future
+    query = {'end':{"$ne":None}}  # Only keep the runs that have an 'end' timestamp
     rundocs = list(runsdb.find(query,
                                projection={'number': 1, 'data': 1, '_id': 1}
                                ).sort('number', pymongo.DESCENDING)[:max_runs])

--- a/amstrax/auto_processing/copy_live.py
+++ b/amstrax/auto_processing/copy_live.py
@@ -108,6 +108,7 @@ def exec_commands_and_cleanup(runsdb: pymongo.collection.Collection,
                               locations: ty.List[ty.Union[str, None]],
                               target_location: str,
                               temporary_location: str,
+                              no_end_loc: str,
                               ):
     """
     For each <rundoc>, copy each of the <locations> if it's not <None>
@@ -127,6 +128,16 @@ def exec_commands_and_cleanup(runsdb: pymongo.collection.Collection,
             logs.warning(f'Do {cmd} for {run}')
             # disable bandit
             copy_execute = subprocess.call(cmd, shell=True)
+
+        # If there is not 'THE_END' file, move the run data to a separate folder
+        # for further investigation
+        else:
+            shutil.move(f'{location}/{run:06d}', no_end_loc)
+            if os.path.exists(f'{no_end_loc}/{run:06d}'):
+                logs.info(f'Run {run} had no end file in the data so '
+                          f'I moved it to {no_end_loc} for further investigation')
+            else:
+                logs.error(f'Whut happened to {run}?!?!')
 
         # If copying was successful, update the runsdatabase
         # with the new location of the data
@@ -172,6 +183,7 @@ def main(args):
     max_runs = args.max_runs
     final_destination = config['final_destination']
     dest_loc = config['dest_location']
+    no_end_loc = config['no_end_destination']
 
     # Initialize runsdatabase collection
     runsdb = amstrax.get_mongo_collection(detector)
@@ -190,6 +202,7 @@ def main(args):
                               locations=locations,
                               target_location=dest_loc,
                               temporary_location=final_destination,
+                              no_end_loc=no_end_loc
                               )
 
     return


### PR DESCRIPTION
Small improvement to the copy_live script: only start copying if the run:

has a 'THE_END' folder within the run data folder on the DAQ computer
therefore only copies when there is actually data (so hopefully no empty chunk problems)