### PR TITLE
Update the documentation page with a XAMSL data access notebook 

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,6 +19,7 @@ Content
     auto_processing_on_stoomboot
     writing_documentation
     making_a_release
+    tutorials/xamsl_data_access.ipynb
 
 
 .. toctree::


### PR DESCRIPTION
This notebook contains informations about the difference between XAMS and XAMSL data-structure, how to access XAMSL data and how to retrieve measurements informations using the `amstrax_files` package.