### PR TITLE
Fix runs being deleted while written

### DIFF
--- a/amstrax/auto_processing/copy_live.py
+++ b/amstrax/auto_processing/copy_live.py
@@ -44,7 +44,7 @@ def get_rundocs(runsdb, args):
 
     base_query = {
         # end is at least 1 second ago
-        'end': {'$lt': datetime.datetime.now() - datetime.timedelta(seconds=10)},
+        'end': {'$lt': datetime.datetime.now() - datetime.timedelta(seconds=30)},
         'number': {'$gt': args.min_run_number},
         'data': {
             '$elemMatch': {

--- a/amstrax/auto_processing/copy_live.py
+++ b/amstrax/auto_processing/copy_live.py
@@ -44,7 +44,7 @@ def get_rundocs(runsdb, args):
 
     base_query = {
         # end is at least 1 second ago
-        'end': {'$lt': datetime.datetime.now() - datetime.timedelta(seconds=1)},
+        'end': {'$lt': datetime.datetime.now() - datetime.timedelta(seconds=10)},
         'number': {'$gt': args.min_run_number},
         'data': {
             '$elemMatch': {

--- a/amstrax/auto_processing/delete_live.py
+++ b/amstrax/auto_processing/delete_live.py
@@ -31,6 +31,8 @@ def get_old_runs(runsdb, days, args):
     """
     cutoff_date = datetime.datetime.now() - datetime.timedelta(days=days)
     query = {
+        # always make sure we do not mess with data currentrly being written
+        'end': {'$lt': datetime.datetime.now() - datetime.timedelta(seconds=30)},
         '$or': [
             {'end': {'$lte': cutoff_date},
             'data': {'$all': [
@@ -45,6 +47,8 @@ def get_old_runs(runsdb, days, args):
 
     if args.only_stoomboot and not args.production:
         query = {
+        # always make sure we do not mess with data currentrly being written
+        'end': {'$lt': datetime.datetime.now() - datetime.timedelta(seconds=30)},
         '$or': [
             {'end': {'$lte': cutoff_date},
             'data': {'$all': [


### PR DESCRIPTION
Runs with abandon tags were deleted while written, creating problems to data taking (ofc).
Now we add a 30sec delay after run ends before we can take it in consideration (even if abandon tag is present).