### PR TITLE
Implement XYZ Position Reconstruction

### DIFF
--- a/amstrax/plugins/events/event_positions.py
+++ b/amstrax/plugins/events/event_positions.py
@@ -2,7 +2,7 @@ import numpy as np
 import amstrax
 
 
-DEFAULT_POSREC_ALGO = 'cgr'
+DEFAULT_POSREC_ALGO = 'corr'
 
 import strax
 
@@ -20,6 +20,12 @@ export, __all__ = strax.exporter()
     strax.Option('default_reconstruction_algorithm',
                  default=DEFAULT_POSREC_ALGO,
                  help="default reconstruction algorithm that provides (x,y)"),
+    strax.Option('chebyshev_coefficients',
+                 default=[-20.610498575132848, -25.011741532892245, 1.5014394901565762, -1.9897069599813497, 0.9003989634988041, -0.9360882311673664, 0.3205446171520987, -0.31507601715307304, -0.11157849428915143, 0.06805340886247688, -0.29731923422516193, 0.20130571476398995, -0.27433679192849914, 0.14124101107660128, -0.1423385040662297, 0.02543495639467936, -0.003942936477649859, -0.06027758452189014, 0.06644908962655806, -0.07892464092207617, 0.06395035504495723, -0.03346169811390071, 0.015301990300138332, 0.02074806803955231, -0.023897590505947888, 0.05290043645359529, -0.04171261919713702, 0.04635244560925833, -0.023740447547251964, 0.017317746198669496, 0.008129269124318644, -0.015813652571722153, 0.03280797293563488, -0.0319597933948091, 0.033244932242107145, -0.02499733182975444, 0.01804703343996559, -0.003734756903266918, -0.010310284576649408, 0.014162576952560277, -0.02107880499178727, 0.02353782385611963, -0.023161397137303634, 0.01638318547950904, -0.009949657230580528, 0.0028289370052051086, 0.00819342916648231, -0.010233170352421222, 0.01760163054647025, -0.01272257423130424, 0.014630281086449799],
+                 help="coefficients for the drift time to z fit"),
+    strax.Option('chebyshev_interval',
+                 default=[1219.0999755859375, 39380.8984375],
+                 help="interval of the chebyshev fit"),
 )
 
 class EventPositions(strax.Plugin):
@@ -33,7 +39,7 @@ class EventPositions(strax.Plugin):
 
     depends_on = ('event_basics',)
 
-    __version__ = '0.4.0'
+    __version__ = '1.1.16'
 
 
     def infer_dtype(self):
@@ -46,6 +52,9 @@ class EventPositions(strax.Plugin):
                 field = f'alt_s{s_i}_{j}'
                 dtype += [(field, np.float32, comment)]
 
+        dtype += [('z', np.float32,
+         'Interaction depth z-position')]
+        
         return dtype + strax.time_fields
 
     def setup(self):
@@ -53,6 +62,8 @@ class EventPositions(strax.Plugin):
         self.electron_drift_velocity = self.config['electron_drift_velocity']
         self.electron_drift_time_gate = self.config['electron_drift_time_gate']
         self.default_reconstruction_algorithm = self.config['default_reconstruction_algorithm']
+        self.chebyshev_coefficients = np.array(self.config['chebyshev_coefficients'])
+        self.chebyshev_interval = self.config['chebyshev_interval']
         
         self.coordinate_scales = [1., 1., - self.electron_drift_velocity]
         # self.map = self.fdc_map
@@ -62,6 +73,7 @@ class EventPositions(strax.Plugin):
         result = {'time': events['time'],
                   'endtime': strax.endtime(events)}
 
+        # cope the values from the S2s
         algo = self.default_reconstruction_algorithm
 
         for j in 'x y'.split():
@@ -74,5 +86,12 @@ class EventPositions(strax.Plugin):
         result['r'] = np.sqrt(result['x'] ** 2 + result['y'] ** 2)
         result['alt_s2_r'] = np.sqrt(result['alt_s2_x'] ** 2 + result['alt_s2_y'] ** 2)
 
+        # determine z using a chebyshev polynomial fit
+        p = np.polynomial.chebyshev.Chebyshev(self.chebyshev_coefficients) 
+        
+        # normalize drift times such that the interval is [-1, 1]
+        drift_times_normalized = 2 * (events['drift_time'] - self.chebyshev_interval[0]) / (self.config['chebyshev_interval'][1] - self.chebyshev_interval[0]) - 1
+
+        result['z'] = p(drift_times_normalized)
 
         return result

--- a/amstrax/plugins/events/event_positions.py
+++ b/amstrax/plugins/events/event_positions.py
@@ -20,12 +20,15 @@ export, __all__ = strax.exporter()
     strax.Option('default_reconstruction_algorithm',
                  default=DEFAULT_POSREC_ALGO,
                  help="default reconstruction algorithm that provides (x,y)"),
-    strax.Option('chebyshev_coefficients',
-                 default=[-20.610498575132848, -25.011741532892245, 1.5014394901565762, -1.9897069599813497, 0.9003989634988041, -0.9360882311673664, 0.3205446171520987, -0.31507601715307304, -0.11157849428915143, 0.06805340886247688, -0.29731923422516193, 0.20130571476398995, -0.27433679192849914, 0.14124101107660128, -0.1423385040662297, 0.02543495639467936, -0.003942936477649859, -0.06027758452189014, 0.06644908962655806, -0.07892464092207617, 0.06395035504495723, -0.03346169811390071, 0.015301990300138332, 0.02074806803955231, -0.023897590505947888, 0.05290043645359529, -0.04171261919713702, 0.04635244560925833, -0.023740447547251964, 0.017317746198669496, 0.008129269124318644, -0.015813652571722153, 0.03280797293563488, -0.0319597933948091, 0.033244932242107145, -0.02499733182975444, 0.01804703343996559, -0.003734756903266918, -0.010310284576649408, 0.014162576952560277, -0.02107880499178727, 0.02353782385611963, -0.023161397137303634, 0.01638318547950904, -0.009949657230580528, 0.0028289370052051086, 0.00819342916648231, -0.010233170352421222, 0.01760163054647025, -0.01272257423130424, 0.014630281086449799],
-                 help="coefficients for the drift time to z fit"),
-    strax.Option('chebyshev_interval',
-                 default=[1219.0999755859375, 39380.8984375],
-                 help="interval of the chebyshev fit"),
+    strax.Option('drift_time_gate',
+                 default=3000,
+                 help='Drift time belonging to the gate in ns'),
+    strax.Option('drift_time_cathode',
+                 default=39500,
+                 help='Drift time belonging to the cathode in ns'),
+    strax.Option('gate_cathode_distance',
+                 default=505,
+                 help='Distance between gate and cathode in mm'),    
 )
 
 class EventPositions(strax.Plugin):
@@ -39,7 +42,7 @@ class EventPositions(strax.Plugin):
 
     depends_on = ('event_basics',)
 
-    __version__ = '1.1.16'
+    __version__ = '1.1.20'
 
 
     def infer_dtype(self):
@@ -62,8 +65,9 @@ class EventPositions(strax.Plugin):
         self.electron_drift_velocity = self.config['electron_drift_velocity']
         self.electron_drift_time_gate = self.config['electron_drift_time_gate']
         self.default_reconstruction_algorithm = self.config['default_reconstruction_algorithm']
-        self.chebyshev_coefficients = np.array(self.config['chebyshev_coefficients'])
-        self.chebyshev_interval = self.config['chebyshev_interval']
+        self.drift_time_gate = self.config['drift_time_gate']
+        self.drift_time_cathode = self.config['drift_time_cathode']
+        self.gate_cathode_distance = self.config['gate_cathode_distance']
         
         self.coordinate_scales = [1., 1., - self.electron_drift_velocity]
         # self.map = self.fdc_map
@@ -86,12 +90,7 @@ class EventPositions(strax.Plugin):
         result['r'] = np.sqrt(result['x'] ** 2 + result['y'] ** 2)
         result['alt_s2_r'] = np.sqrt(result['alt_s2_x'] ** 2 + result['alt_s2_y'] ** 2)
 
-        # determine z using a chebyshev polynomial fit
-        p = np.polynomial.chebyshev.Chebyshev(self.chebyshev_coefficients) 
-        
-        # normalize drift times such that the interval is [-1, 1]
-        drift_times_normalized = 2 * (events['drift_time'] - self.chebyshev_interval[0]) / (self.config['chebyshev_interval'][1] - self.chebyshev_interval[0]) - 1
-
-        result['z'] = p(drift_times_normalized)
+        slope = -self.gate_cathode_distance / (self.drift_time_cathode - self.drift_time_gate)
+        result['z'] = slope * (events['drift_time'] - self.drift_time_gate)
 
         return result

--- a/amstrax/plugins/events/event_positions.py
+++ b/amstrax/plugins/events/event_positions.py
@@ -11,12 +11,6 @@ export, __all__ = strax.exporter()
 
 @export
 @strax.takes_config(
-    strax.Option('electron_drift_velocity',
-                 default=0.0000016,
-                 help='Vertical electron drift velocity in cm/ns (1e4 m/ms)'),
-    strax.Option('electron_drift_time_gate',
-                 default=1,
-                 help='Electron drift time from the gate in ns'),
     strax.Option('default_reconstruction_algorithm',
                  default=DEFAULT_POSREC_ALGO,
                  help="default reconstruction algorithm that provides (x,y)"),
@@ -62,16 +56,11 @@ class EventPositions(strax.Plugin):
 
     def setup(self):
 
-        self.electron_drift_velocity = self.config['electron_drift_velocity']
-        self.electron_drift_time_gate = self.config['electron_drift_time_gate']
         self.default_reconstruction_algorithm = self.config['default_reconstruction_algorithm']
         self.drift_time_gate = self.config['drift_time_gate']
         self.drift_time_cathode = self.config['drift_time_cathode']
         self.gate_cathode_distance = self.config['gate_cathode_distance']
         
-        self.coordinate_scales = [1., 1., - self.electron_drift_velocity]
-        # self.map = self.fdc_map
-
     def compute(self, events):
 
         result = {'time': events['time'],

--- a/amstrax/plugins/peaks/peak_positions.py
+++ b/amstrax/plugins/peaks/peak_positions.py
@@ -4,9 +4,6 @@ import strax
 from immutabledict import immutabledict
 export, __all__ = strax.exporter()
 
-# size of a single mesh cell in mm
-MESH_SIZE = 2.6
-
 DEFAULT_POSREC_ALGO = 'corr'
 
 @export
@@ -35,7 +32,7 @@ DEFAULT_POSREC_ALGO = 'corr'
 class PeakPositions(strax.Plugin):
     depends_on = ('peaks', 'peak_basics')
     rechunk_on_save = False
-    __version__ = '1.2.9'
+    __version__ = '1.2.10'
     dtype = [
         ('x_cgr', np.float32,
          'Interaction x_cgr-position center of gravity'),
@@ -90,8 +87,8 @@ class PeakPositions(strax.Plugin):
         rec_function_x = np.poly1d(np.array(self.config['px']))
         rec_function_y = np.poly1d(np.array(self.config['py']))
         
-        result['x_corr'] = rec_function_x(result['x_cgr']) * MESH_SIZE
-        result['y_corr'] = rec_function_y(result['y_cgr']) * MESH_SIZE
+        result['x_corr'] = rec_function_x(result['x_cgr'])
+        result['y_corr'] = rec_function_y(result['y_cgr'])
         result['r_corr'] = np.sqrt(result['x_corr']**2+result['y_corr']**2)
 
         # set x, y, z to be the values from the default reconstruction algorithm

--- a/amstrax/plugins/peaks/peak_positions.py
+++ b/amstrax/plugins/peaks/peak_positions.py
@@ -4,34 +4,67 @@ import strax
 from immutabledict import immutabledict
 export, __all__ = strax.exporter()
 
+# size of a single mesh cell in mm
+MESH_SIZE = 2.6
+
+DEFAULT_POSREC_ALGO = 'corr'
 
 @export
 @strax.takes_config(
-        strax.Option(
+    strax.Option(
         "channel_map",
         type=immutabledict,
         track=False,
         help="Map of channel numbers to top, bottom and aqmon, to be defined in the context",
     ),
+    strax.Option('default_reconstruction_algorithm',
+                 default=DEFAULT_POSREC_ALGO,
+                 help="default reconstruction algorithm that provides (x,y)"
+    ),
+    strax.Option(
+        'px', 
+        default=[81.54492347, -122.86180405, 76.13265045, -17.66706185],
+        help="Parameters for a correction function to go from x_cgr to true x"
+    ),
+    strax.Option(
+        'py', 
+        default=[79.21010097, -120.15755073, 75.33693986, -17.69562578],
+        help="Parameters for a correction function to go from y_cgr to true y"
+    ),
 )
 class PeakPositions(strax.Plugin):
     depends_on = ('peaks', 'peak_basics')
     rechunk_on_save = False
-    __version__ = '1.0'
+    __version__ = '1.2.9'
     dtype = [
         ('x_cgr', np.float32,
-         'Interaction x-position center of gravity'),
+         'Interaction x_cgr-position center of gravity'),
         ('y_cgr', np.float32,
-         'Interaction y-position center of gravity'),
+         'Interaction y_cgr-position center of gravity'),
         ('r_cgr', np.float32,
          'radial distance from center of gravity'),
+        ('x_corr', np.float32,
+         'Corrected interaction x-position'),
+        ('y_corr', np.float32,
+         'Corrected interaction y-position'),
+        ('r_corr', np.float32,
+         'Corrected radial distance from center'),
+        ('x', np.float32,
+         'Interaction x-position for the default reconstruction algorithm'),
+        ('y', np.float32,
+         'Interaction y-position for the default reconstruction algorithm'),
+        ('r', np.float32,
+         'Interaction r for the default reconstruction algorithm'),
         ('time', np.int64, 'Start time of the peak (ns since unix epoch)'),
         ('endtime', np.int64, 'End time of the peak (ns since unix epoch)')
     ]
 
+    def setup(self):
+        
+        self.default_reconstruction_algorithm = self.config['default_reconstruction_algorithm']
 
     def compute(self, peaks):
-
+                
         result = np.empty(len(peaks), dtype=self.dtype)
         result['time'] = peaks['time']
         result['endtime'] = peaks['endtime']
@@ -53,4 +86,18 @@ class PeakPositions(strax.Plugin):
         result['y_cgr'] = f_13
         result['r_cgr'] = np.sqrt(result['x_cgr']**2+result['y_cgr']**2)
 
+        # correct the x and y cgr positions
+        rec_function_x = np.poly1d(np.array(self.config['px']))
+        rec_function_y = np.poly1d(np.array(self.config['py']))
+        
+        result['x_corr'] = rec_function_x(result['x_cgr']) * MESH_SIZE
+        result['y_corr'] = rec_function_y(result['y_cgr']) * MESH_SIZE
+        result['r_corr'] = np.sqrt(result['x_corr']**2+result['y_corr']**2)
+
+        # set x, y, z to be the values from the default reconstruction algorithm
+        algo = self.default_reconstruction_algorithm
+        result['x'] = result[f'x_{algo}']
+        result['y'] = result[f'y_{algo}']
+        result['r'] = result[f'r_{algo}']
+        
         return result

--- a/amstrax/plugins/peaks/peak_positions.py
+++ b/amstrax/plugins/peaks/peak_positions.py
@@ -23,12 +23,12 @@ DEFAULT_POSREC_ALGO = 'corr'
     ),
     strax.Option(
         'px', 
-        default=[81.54492347, -122.86180405, 76.13265045, -17.66706185],
+        default=[212.89988642, -320.95097295, 198.71830514, -46.03953999],
         help="Parameters for a correction function to go from x_cgr to true x"
     ),
     strax.Option(
         'py', 
-        default=[79.21010097, -120.15755073, 75.33693986, -17.69562578],
+        default=[211.40051359, -319.83147964, 198.69552524, -46.23585688],
         help="Parameters for a correction function to go from y_cgr to true y"
     ),
 )


### PR DESCRIPTION
Implemented an xy-position reconstruction as described in Tobias' master thesis, where we use the dots in the charge ratio distribution to relate it to real xy positions in the TPC.

Calibrated on the gate and cathode positions to make a linear z position reconstruction.