### PR TITLE
Use --set_config_kwargs for autoprocessing

### DIFF
--- a/amstrax/auto_processing_new/auto_processing.py
+++ b/amstrax/auto_processing_new/auto_processing.py
@@ -218,7 +218,7 @@ def submit_new_jobs(args, runs_col, run_docs_to_do, amstrax_dir):
             arguments.append("--allow_raw_records")
             arguments.append("--is_online")
         if args.set_config_kwargs:
-            config_kwargs = json.loads(args.set_config_kwargs)
+            config_kwargs = json.dumps(args.set_config_kwargs, separators=(',',':')
             arguments.append(f"--set_config_kwargs {config_kwargs}")
 
         arguments = " ".join(arguments)

--- a/amstrax/auto_processing_new/auto_processing.py
+++ b/amstrax/auto_processing_new/auto_processing.py
@@ -218,7 +218,8 @@ def submit_new_jobs(args, runs_col, run_docs_to_do, amstrax_dir):
             arguments.append("--allow_raw_records")
             arguments.append("--is_online")
         if args.set_config_kwargs:
-            arguments.append(f"--set_config_kwargs {args.set_config_kwargs}")
+            config_kwargs = json.loads(args.set_config_kwargs)
+            arguments.append(f"--set_config_kwargs {config_kwargs}")
 
         arguments = " ".join(arguments)
 

--- a/amstrax/auto_processing_new/auto_processing.py
+++ b/amstrax/auto_processing_new/auto_processing.py
@@ -3,6 +3,7 @@ import time
 import os
 import logging
 from datetime import datetime, timedelta
+import json
 
 from job_submission import submit_job
 from db_utils import update_processing_status
@@ -37,7 +38,7 @@ def parse_args():
     parser.add_argument("--logs_path", default="/data/xenon/xams_v2/logs/", help="Path to save job logs.")
     parser.add_argument("--production", action="store_true", help="Run in production mode (will update the rundb).")
     parser.add_argument("--set_config_kwargs", default="{}", help="Dictionary of kwargs to pass to set_config.")
-    parser.add_argument("--set_context_kwargs", default="{}", help="Dictionary of kwargs to pass to set_context.")
+    parser.add_argument("--set_context_kwargs", type=json.loads, default="{}", help="Dictionary of kwargs to pass to set_context.")
     parser.add_argument("--amstrax_path", default=None, help="Path to the amstrax directory.")
     parser.add_argument("--corrections_version", default=None, help="Version of corrections to use.")
     parser.add_argument("--queue", default="short", help="Queue to submit jobs to. See Nikhef docs for options.")

--- a/amstrax/auto_processing_new/auto_processing.py
+++ b/amstrax/auto_processing_new/auto_processing.py
@@ -216,6 +216,8 @@ def submit_new_jobs(args, runs_col, run_docs_to_do, amstrax_dir):
             arguments.append("--production")
             arguments.append("--allow_raw_records")
             arguments.append("--is_online")
+        if args.set_config_kwargs:
+            arguments.append(f"--set_config_kwargs {args.set_config_kwargs}")
 
         arguments = " ".join(arguments)
 

--- a/amstrax/auto_processing_new/auto_processing.py
+++ b/amstrax/auto_processing_new/auto_processing.py
@@ -218,7 +218,7 @@ def submit_new_jobs(args, runs_col, run_docs_to_do, amstrax_dir):
             arguments.append("--allow_raw_records")
             arguments.append("--is_online")
         if args.set_config_kwargs:
-            config_kwargs = json.dumps(args.set_config_kwargs, separators=(',',':')
+            config_kwargs = json.dumps(args.set_config_kwargs, separators=(',',':'))
             arguments.append(f"--set_config_kwargs {config_kwargs}")
 
         arguments = " ".join(arguments)

--- a/amstrax/auto_processing_new/process.py
+++ b/amstrax/auto_processing_new/process.py
@@ -266,7 +266,7 @@ class RunProcessor:
         )
         st.storage += [strax.DataDirectory(raw_records_folder, readonly=True)]
 
-        if args.set_config_kwargs and isinstance(self.set_config_kwargs, dict):
+        if self.set_config_kwargs and isinstance(self.set_config_kwargs, dict):
             st.set_config(self.set_config_kwargs)
 
 

--- a/amstrax/auto_processing_new/process.py
+++ b/amstrax/auto_processing_new/process.py
@@ -1,7 +1,6 @@
 # processing.py
 import os
 import sys
-import json
 import logging
 import argparse
 import strax
@@ -307,7 +306,7 @@ def parse_args():
     parser.add_argument("--production", action="store_true", help="Update the production database.")
     parser.add_argument("--is_online", action="store_true", help="Process online data.")
     parser.add_argument("--fix_targets", action="store_true", help="Fix the targets to process, do not allow special modes.")
-    parser.add_argument("--set_config_kwargs", type=json.loads, default="{}", help="Dictionary of kwargs to pass to set_config.")
+    parser.add_argument("--set_config_kwargs", default="{}", help="Dictionary of kwargs to pass to set_config.")
 
     return parser.parse_args()
 

--- a/amstrax/auto_processing_new/process.py
+++ b/amstrax/auto_processing_new/process.py
@@ -2,6 +2,7 @@
 import os
 import sys
 import logging
+import json
 import argparse
 import strax
 import socket
@@ -306,7 +307,7 @@ def parse_args():
     parser.add_argument("--production", action="store_true", help="Update the production database.")
     parser.add_argument("--is_online", action="store_true", help="Process online data.")
     parser.add_argument("--fix_targets", action="store_true", help="Fix the targets to process, do not allow special modes.")
-    parser.add_argument("--set_config_kwargs", default="{}", help="Dictionary of kwargs to pass to set_config.")
+    parser.add_argument("--set_config_kwargs", type=json.loads, default="{}", help="Dictionary of kwargs to pass to set_config.")
 
     return parser.parse_args()
 

--- a/amstrax/auto_processing_new/process.py
+++ b/amstrax/auto_processing_new/process.py
@@ -1,6 +1,7 @@
 # processing.py
 import os
 import sys
+import json
 import logging
 import argparse
 import strax
@@ -306,7 +307,7 @@ def parse_args():
     parser.add_argument("--production", action="store_true", help="Update the production database.")
     parser.add_argument("--is_online", action="store_true", help="Process online data.")
     parser.add_argument("--fix_targets", action="store_true", help="Fix the targets to process, do not allow special modes.")
-    parser.add_argument("--set_config_kwargs", type=dict, default="{}", help="Dictionary of kwargs to pass to set_config.")
+    parser.add_argument("--set_config_kwargs", type=json.loads, default="{}", help="Dictionary of kwargs to pass to set_config.")
 
     return parser.parse_args()
 

--- a/amstrax/auto_processing_new/process.py
+++ b/amstrax/auto_processing_new/process.py
@@ -23,6 +23,7 @@ class RunProcessor:
         self.amstrax_path = args.amstrax_path
         self.is_online = args.is_online
         self.fix_targets = args.fix_targets
+        self.set_config_kwargs = args.set_config_kwargs
         
         if self.amstrax_path:
             self.amstrax_path = self.amstrax_path.rstrip("/")
@@ -264,6 +265,9 @@ class RunProcessor:
         )
         st.storage += [strax.DataDirectory(raw_records_folder, readonly=True)]
 
+        if args.set_config_kwargs and isinstance(self.set_config_kwargs, dict):
+            st.set_config(self.set_config_kwargs)
+
 
         if not self.fix_targets:
             st = self.infer_special_modes(st)
@@ -302,6 +306,7 @@ def parse_args():
     parser.add_argument("--production", action="store_true", help="Update the production database.")
     parser.add_argument("--is_online", action="store_true", help="Process online data.")
     parser.add_argument("--fix_targets", action="store_true", help="Fix the targets to process, do not allow special modes.")
+    parser.add_argument("--set_config_kwargs", type=dict, default="{}", help="Dictionary of kwargs to pass to set_config.")
 
     return parser.parse_args()
 


### PR DESCRIPTION
Somehow I needed this when I wanted to reprocess with different gains, but then just changing the development file of the corrections was not sufficient, because then it doesn't change the hash and I didn't want to remove the existing data. It is a bit tacky since I need to pass the "dict" twice, but it worked like this.