### PR TITLE
Make records_led robust to variable record_i per pulse/channel

### DIFF
--- a/amstrax/plugins/led_calibration/records_led.py
+++ b/amstrax/plugins/led_calibration/records_led.py
@@ -1,6 +1,4 @@
-from immutabledict import immutabledict
 import strax
-import numba
 import numpy as np
 
 export, __all__ = strax.exporter()
@@ -18,10 +16,6 @@ export, __all__ = strax.exporter()
     strax.Option('n_records_per_pulse',
         default=2, type=int,
         help="how many samples per pulse"),
-
-    strax.Option('record_length',
-        default=110, track=False, type=int,
-                 help="Number of samples per raw_record")
 )
 class RecordsLED(strax.Plugin):
     """
@@ -61,27 +55,63 @@ class RecordsLED(strax.Plugin):
         '''
         Carlo needs to explain
         '''
+        if len(raw_records) == 0:
+            return np.zeros(0, dtype=self.dtype)
 
-        record_length = np.shape(raw_records.dtype['data'])[0]
-        n_record_i = np.max(raw_records['record_i'])+1
-        num_channels = int(len(np.unique(raw_records['channel'])))
+        # Group fragments by pulse start time + channel.
+        # This is robust to variable record_i multiplicity per pulse/channel.
+        rec_len = int(np.shape(raw_records.dtype["data"])[0])
+        dt = raw_records["dt"].astype(np.int64)
+        rec_i = raw_records["record_i"].astype(np.int64)
+        pulse_start = raw_records["time"].astype(np.int64) - rec_i * rec_len * dt
+        group_keys = np.core.records.fromarrays(
+            [pulse_start, raw_records["channel"]],
+            names="pulse_start,channel",
+        )
+        _, group_first_idx, group_inverse = np.unique(
+            group_keys, return_index=True, return_inverse=True
+        )
 
-        records = np.zeros(int(len(raw_records)/n_record_i), dtype=self.dtype)
+        records = np.zeros(len(group_first_idx), dtype=self.dtype)
+        out_wave_len = self.dtype["data"].shape[0]
 
-        datas = [raw_records[np.where(raw_records['record_i'] == i)[0]] for i in range(n_record_i)]
+        for out_i in range(len(group_first_idx)):
+            idx = np.where(group_inverse == out_i)[0]
+            fragments = raw_records[idx]
+            order = np.argsort(fragments["record_i"], kind="stable")
+            fragments = fragments[order]
 
-        for i, name in enumerate(raw_records.dtype.names):
-            if name == 'data':  
-                records[name] = np.hstack(list(datas[i][name] for i in range(n_record_i)))
-            if name == 'length':
-                records[name] = np.sum(list(datas[i][name] for i in range(n_record_i)), axis=0)
-            else:
-                try:
-                    records[name] = datas[0][name]
-                except:
-                    pass
-        
-        bl = records['data'][:, self.baseline_window[0]:self.baseline_window[1]].mean(axis=1)
-        records['data'] = -1. * (records['data'].transpose() - bl[:]).transpose()
+            # Copy scalar/meta fields from first fragment
+            first = fragments[0]
+            records[out_i]["time"] = first["time"]
+            records[out_i]["dt"] = first["dt"]
+            records[out_i]["channel"] = first["channel"]
+            records[out_i]["pulse_length"] = np.max(fragments["pulse_length"])
+            records[out_i]["record_i"] = 0
+
+            # Concatenate variable fragment waveforms, then truncate/pad to fixed LED size.
+            parts = []
+            total_length = 0
+            for frag in fragments:
+                frag_len = int(max(0, min(rec_len, frag["length"])))
+                if frag_len == 0:
+                    continue
+                piece = frag["data"][:frag_len].astype(np.float32, copy=False)
+                parts.append(piece)
+                total_length += frag_len
+
+            if parts:
+                wf = np.concatenate(parts)
+                clip_len = min(len(wf), out_wave_len)
+                records[out_i]["data"][:clip_len] = wf[:clip_len]
+            records[out_i]["length"] = min(total_length, out_wave_len)
+
+        bl_lo, bl_hi = self.baseline_window
+        bl_lo = max(0, int(bl_lo))
+        bl_hi = min(records["data"].shape[1], int(bl_hi))
+        if bl_hi <= bl_lo:
+            bl_lo, bl_hi = 0, min(50, records["data"].shape[1])
+        bl = records["data"][:, bl_lo:bl_hi].mean(axis=1)
+        records["data"] = -1.0 * (records["data"].transpose() - bl[:]).transpose()
 
         return records


### PR DESCRIPTION
## Summary
This PR fixes LED processing failures when `raw_records` have variable fragment multiplicity (`record_i`) across pulses/channels.

## Problem
`records_led` previously assumed a fixed global `n_record_i` and tried to stack/sum arrays by index across the full chunk. This fails with:
- `ValueError: setting an array element with a sequence`
when different pulses have different numbers of fragments.

## Changes
- Group raw record fragments per pulse using `(pulse_start, channel)` where `pulse_start = time - record_i * record_length * dt`.
- Sort fragments by `record_i` within each pulse.
- Concatenate fragment waveforms safely per pulse.
- Truncate/pad to the fixed output waveform length (`record_length * n_records_per_pulse`).
- Compute output `length` from total concatenated fragment lengths (clipped to output size).
- Keep baseline subtraction with safe bounds.
- Handle empty input chunks explicitly.

## Notes
- This makes `records_led` resilient to realistic DAQ behavior where external trigger does not guarantee uniform pulse fragmentation across channels.
- Existing behavior for well-formed fixed-fragment runs is preserved.