### PR TITLE
Move LED polarity handling out of DAQReader

### DIFF
--- a/amstrax/__init__.py
+++ b/amstrax/__init__.py
@@ -10,6 +10,9 @@ from .xams_config import *
 from . import corrections_services
 from .corrections_services import *
 
+from . import daq_config
+from .daq_config import *
+
 from . import plugins
 from .plugins import *
 

--- a/amstrax/contexts.py
+++ b/amstrax/contexts.py
@@ -155,10 +155,9 @@ def context_for_daq_reader(
     daq_config = run_doc["daq_config"]
     _set_optional_channel_map(st=st, run_doc=run_doc)
     input_dir = _resolve_input_dir_for_daq_reader(st=st, run_id=run_id, daq_config=daq_config)
-    channel_polarity_map = _extract_channel_polarity(daq_config['registers'])
 
     st.set_context_config(dict(forbid_creation_of=tuple()))
-    st.set_config(_build_daq_reader_config(run_doc=run_doc, daq_config=daq_config, input_dir=input_dir, channel_polarity_map=channel_polarity_map))
+    st.set_config(_build_daq_reader_config(run_doc=run_doc, daq_config=daq_config, input_dir=input_dir))
     UserWarning(f'You changed the context for {run_id}. Do not process any other run!')
     return st
 
@@ -206,27 +205,7 @@ def _resolve_input_dir_for_daq_reader(st: strax.Context, run_id: str, daq_config
     return input_dir
 
 
-def _extract_channel_polarity(registers) -> dict:
-    channel_polarity = {}
-    for reg in registers:
-        reg_addr = reg['reg'].lower()
-        reg_val = reg['val'].lower()
-        if not (reg_addr.startswith('1') and reg_addr.endswith('80')):
-            continue
-        try:
-            chan_num = (int(reg_addr, 16) - 0x1080) // 0x100
-            if reg_val in ("110000", "1110000"):
-                channel_polarity[chan_num] = -1
-            elif reg_val in ("100000", "1100000"):
-                channel_polarity[chan_num] = 1
-            else:
-                raise ValueError(f"Unknown polarity config value '{reg_val}' for channel {chan_num}")
-        except Exception as err:
-            print(f"Error parsing register {reg_addr} with value {reg_val}: {err}")
-    return channel_polarity
-
-
-def _build_daq_reader_config(run_doc: dict, daq_config: dict, input_dir: str, channel_polarity_map: dict) -> dict:
+def _build_daq_reader_config(run_doc: dict, daq_config: dict, input_dir: str) -> dict:
     return {
         'readout_threads': daq_config['processing_threads'],
         'daq_input_dir': input_dir,
@@ -236,13 +215,12 @@ def _build_daq_reader_config(run_doc: dict, daq_config: dict, input_dir: str, ch
         'daq_chunk_duration': int(daq_config['strax_chunk_length'] * 1e9),
         'daq_overlap_chunk_duration': int(daq_config['strax_chunk_overlap'] * 1e9),
         'compressor': daq_config.get('compressor', 'lz4'),
-        'channels_polarity': channel_polarity_map,
     }
 
 
 def xams_led(**kwargs):
     st = xams(**kwargs)
-    st.set_context_config({"check_available": ("raw_records", "records_led", "led_calibration")})
+    st.set_context_config({"check_available": ("raw_records", "raw_records_sipm", "records_led", "led_calibration")})
     # Return a new context with only raw_records and led_calibration registered
     st = st.new_context(replace=True, config=st.config, storage=st.storage, **st.context_config)
     st.register([ax.DAQReader, ax.RecordsLED, ax.LEDCalibration])

--- a/amstrax/daq_config.py
+++ b/amstrax/daq_config.py
@@ -1,0 +1,40 @@
+import typing as ty
+
+import numpy as np
+import strax
+
+export, __all__ = strax.exporter()
+
+
+@export
+def extract_channel_polarity(registers: ty.Iterable[dict]) -> dict:
+    """Extract CAEN channel polarity from per-channel DPP control registers."""
+    channel_polarity = {}
+    for reg in registers or []:
+        reg_addr = str(reg.get("reg", "")).lower()
+        reg_val = str(reg.get("val", "")).lower()
+        if not (reg_addr.startswith("1") and reg_addr.endswith("80")):
+            continue
+        try:
+            chan_num = (int(reg_addr, 16) - 0x1080) // 0x100
+            if reg_val in ("110000", "1110000"):
+                channel_polarity[chan_num] = -1
+            elif reg_val in ("100000", "1100000"):
+                channel_polarity[chan_num] = 1
+            else:
+                raise ValueError(f"Unknown polarity config value '{reg_val}' for channel {chan_num}")
+        except Exception as err:
+            print(f"Error parsing register {reg_addr} with value {reg_val}: {err}")
+    return channel_polarity
+
+
+@export
+def channels_in_map_group(channel_map: dict, group: str) -> set:
+    """Return integer channel numbers from a channel-map group."""
+    if not isinstance(channel_map, dict):
+        return set()
+    group_range = channel_map.get(group)
+    if not isinstance(group_range, (list, tuple)) or len(group_range) != 2:
+        return set()
+    left, right = (int(group_range[0]), int(group_range[1]))
+    return set(np.arange(left, right + 1, dtype=np.int64).tolist())

--- a/amstrax/daq_config.py
+++ b/amstrax/daq_config.py
@@ -1,4 +1,5 @@
 import typing as ty
+import json
 
 import numpy as np
 import strax
@@ -9,8 +10,21 @@ export, __all__ = strax.exporter()
 @export
 def extract_channel_polarity(registers: ty.Iterable[dict]) -> dict:
     """Extract CAEN channel polarity from per-channel DPP control registers."""
+    if isinstance(registers, str):
+        try:
+            registers = json.loads(registers)
+        except json.JSONDecodeError as err:
+            raise TypeError(
+                "DAQ registers must be a list of register dictionaries, not an unresolved string. "
+                "If this is a rundoc:// config, access it through the XAMSConfig descriptor."
+            ) from err
+    if isinstance(registers, dict):
+        registers = registers.values()
+
     channel_polarity = {}
     for reg in registers or []:
+        if not isinstance(reg, dict):
+            raise TypeError(f"DAQ register entries must be dictionaries, got {type(reg).__name__}: {reg!r}")
         reg_addr = str(reg.get("reg", "")).lower()
         reg_val = str(reg.get("val", "")).lower()
         if not (reg_addr.startswith("1") and reg_addr.endswith("80")):

--- a/amstrax/plugins/led_calibration/records_led.py
+++ b/amstrax/plugins/led_calibration/records_led.py
@@ -1,6 +1,5 @@
 import strax
 import numpy as np
-from immutabledict import immutabledict
 
 import amstrax
 
@@ -28,14 +27,6 @@ export, __all__ = strax.exporter()
         help="DAQ register list from rundoc, used to infer channel polarity.",
     ),
 
-    amstrax.XAMSConfig(
-        name="channel_map",
-        default="rundoc://?path=xams_bookkeeping.channel_map&fallback=xams_default",
-        track=False,
-        type=immutabledict,
-        infer_type=False,
-        help="Channel map loaded from rundoc.",
-    ),
 )
 class RecordsLED(strax.Plugin):
     """
@@ -59,7 +50,6 @@ class RecordsLED(strax.Plugin):
         self.baseline_window = self.config['baseline_window']
         self.n_records_per_pulse = self.config['n_records_per_pulse']
         self.channel_polarity = amstrax.extract_channel_polarity(self.config['daq_registers'])
-        self.sipm_channels = amstrax.channels_in_map_group(self.config['channel_map'], 'sipm')
 
     def infer_dtype(self):
 
@@ -134,9 +124,7 @@ class RecordsLED(strax.Plugin):
         bl_hi = min(records["data"].shape[1], int(bl_hi))
         if bl_hi <= bl_lo:
             bl_lo, bl_hi = 0, min(50, records["data"].shape[1])
-        bl = records["data"][:, bl_lo:bl_hi].mean(axis=1)
-        records["data"] = -1.0 * (records["data"].transpose() - bl[:]).transpose()
-        self._restore_positive_polarity_channels(records)
+        self._baseline_and_flip(records, bl_lo=bl_lo, bl_hi=bl_hi)
 
         return records
 
@@ -149,13 +137,13 @@ class RecordsLED(strax.Plugin):
             return arrays[0]
         return strax.sort_by_time(np.concatenate(arrays))
 
-    def _restore_positive_polarity_channels(self, records):
-        """
-        records_led historically flips all channels after baselining.
-        Keep that PMT convention, but undo it for positive-polarity channels
-        and for channels explicitly marked as SiPM in the channel map.
-        """
-        for channel in np.unique(records["channel"]):
-            ch = int(channel)
-            if self.channel_polarity.get(ch) == 1 or ch in self.sipm_channels:
-                records["data"][records["channel"] == channel] *= -1.0
+    def _baseline_and_flip(self, records, bl_lo, bl_hi):
+        """Baseline records and flip only channels configured as negative polarity."""
+        for record in records:
+            length = int(max(0, min(record["length"], len(record["data"]))))
+            if length == 0:
+                continue
+            baseline = record["data"][bl_lo:bl_hi].mean()
+            sign = -1.0 if self.channel_polarity.get(int(record["channel"]), -1) == -1 else 1.0
+            record["data"][:length] = sign * (record["data"][:length] - baseline)
+            record["data"][length:] = 0.0

--- a/amstrax/plugins/led_calibration/records_led.py
+++ b/amstrax/plugins/led_calibration/records_led.py
@@ -1,5 +1,8 @@
 import strax
 import numpy as np
+from immutabledict import immutabledict
+
+import amstrax
 
 export, __all__ = strax.exporter()
 
@@ -16,15 +19,32 @@ export, __all__ = strax.exporter()
     strax.Option('n_records_per_pulse',
         default=2, type=int,
         help="how many samples per pulse"),
+
+    amstrax.XAMSConfig(
+        name="daq_registers",
+        default="rundoc://?path=daq_config.registers&fallback=empty",
+        track=False,
+        infer_type=False,
+        help="DAQ register list from rundoc, used to infer channel polarity.",
+    ),
+
+    amstrax.XAMSConfig(
+        name="channel_map",
+        default="rundoc://?path=xams_bookkeeping.channel_map&fallback=xams_default",
+        track=False,
+        type=immutabledict,
+        infer_type=False,
+        help="Channel map loaded from rundoc.",
+    ),
 )
 class RecordsLED(strax.Plugin):
     """
     Carlo needs to explain
     """
 
-    __version__ = '1.0.0'
+    __version__ = '1.1.0'
 
-    depends_on = ('raw_records',)
+    depends_on = ('raw_records', 'raw_records_sipm')
     data_kind = 'records_led'
     provides = 'records_led'
     compressor = 'zstd'
@@ -38,6 +58,8 @@ class RecordsLED(strax.Plugin):
         self.record_length = self.config['record_length']
         self.baseline_window = self.config['baseline_window']
         self.n_records_per_pulse = self.config['n_records_per_pulse']
+        self.channel_polarity = amstrax.extract_channel_polarity(self.config['daq_registers'])
+        self.sipm_channels = amstrax.channels_in_map_group(self.config['channel_map'], 'sipm')
 
     def infer_dtype(self):
 
@@ -51,10 +73,11 @@ class RecordsLED(strax.Plugin):
             
         return dtype 
 
-    def compute(self, raw_records):
+    def compute(self, raw_records, raw_records_sipm):
         '''
         Carlo needs to explain
         '''
+        raw_records = self._combine_raw_records(raw_records, raw_records_sipm)
         if len(raw_records) == 0:
             return np.zeros(0, dtype=self.dtype)
 
@@ -113,5 +136,26 @@ class RecordsLED(strax.Plugin):
             bl_lo, bl_hi = 0, min(50, records["data"].shape[1])
         bl = records["data"][:, bl_lo:bl_hi].mean(axis=1)
         records["data"] = -1.0 * (records["data"].transpose() - bl[:]).transpose()
+        self._restore_positive_polarity_channels(records)
 
         return records
+
+    @staticmethod
+    def _combine_raw_records(*raw_records):
+        arrays = [r for r in raw_records if len(r)]
+        if not arrays:
+            return raw_records[0]
+        if len(arrays) == 1:
+            return arrays[0]
+        return strax.sort_by_time(np.concatenate(arrays))
+
+    def _restore_positive_polarity_channels(self, records):
+        """
+        records_led historically flips all channels after baselining.
+        Keep that PMT convention, but undo it for positive-polarity channels
+        and for channels explicitly marked as SiPM in the channel map.
+        """
+        for channel in np.unique(records["channel"]):
+            ch = int(channel)
+            if self.channel_polarity.get(ch) == 1 or ch in self.sipm_channels:
+                records["data"][records["channel"] == channel] *= -1.0

--- a/amstrax/plugins/led_calibration/records_led.py
+++ b/amstrax/plugins/led_calibration/records_led.py
@@ -49,7 +49,8 @@ class RecordsLED(strax.Plugin):
         self.record_length = self.config['record_length']
         self.baseline_window = self.config['baseline_window']
         self.n_records_per_pulse = self.config['n_records_per_pulse']
-        self.channel_polarity = amstrax.extract_channel_polarity(self.daq_registers)
+        daq_registers = self.takes_config["daq_registers"].__get__(self)
+        self.channel_polarity = amstrax.extract_channel_polarity(daq_registers)
 
     def infer_dtype(self):
 

--- a/amstrax/plugins/led_calibration/records_led.py
+++ b/amstrax/plugins/led_calibration/records_led.py
@@ -49,7 +49,7 @@ class RecordsLED(strax.Plugin):
         self.record_length = self.config['record_length']
         self.baseline_window = self.config['baseline_window']
         self.n_records_per_pulse = self.config['n_records_per_pulse']
-        self.channel_polarity = amstrax.extract_channel_polarity(self.config['daq_registers'])
+        self.channel_polarity = amstrax.extract_channel_polarity(self.daq_registers)
 
     def infer_dtype(self):
 

--- a/amstrax/plugins/raw_records/daqreader.py
+++ b/amstrax/plugins/raw_records/daqreader.py
@@ -72,16 +72,6 @@ class ArtificialDeadtimeInserted(UserWarning):
             "specify the reader and value the number of threads"
         ),
     ),
-    strax.Option(
-        "channels_polarity",
-        type=dict,
-        track=False,
-        default=immutabledict({}),
-        help=(
-            "Dictionary of the channels where the keys specify "
-            "the channel and value the polarity of the channel"
-        ),
-    ),
     strax.Option("daq_input_dir", type=str, track=False, help="Directory where readers put data"),
     # DAQReader settings
     strax.Option(
@@ -133,7 +123,7 @@ class DAQReader(strax.Plugin):
         raw_records_sipm=False,
     )
     compressor = "lz4"
-    __version__ = "0.0.0"
+    __version__ = "0.1.0"
     input_timeout = 300
 
 
@@ -360,14 +350,6 @@ class DAQReader(strax.Plugin):
             print(f"\tChannel {channel} has {count} records")        
 
 
-        for channel, polarity in self.config["channels_polarity"].items():
-            if polarity == 1:
-                # This means that the polarity of this channel is positive
-                # most likely a SiPM channel
-                # usually we work with PMTs with negative polarity
-                # so for convenience we invert the polarity here
-                records["data"][records["channel"] == channel] *= -1
-    
         # Split records by channel
         tpc_min = min(self.config['channel_map']['bottom'][0], self.config['channel_map']['top'][0])
         tpc_max = max(self.config['channel_map']['bottom'][1], self.config['channel_map']['top'][1])

--- a/amstrax/plugins/records_ext/pulse_processing_sipm.py
+++ b/amstrax/plugins/records_ext/pulse_processing_sipm.py
@@ -23,7 +23,7 @@ class PulseProcessingSiPM(strax.Plugin):
     5. Pulse length and area calculation
 
     """
-    __version__ = '0.0.1'
+    __version__ = '0.0.2'
     
     parallel = 'process'
     rechunk_on_save = False
@@ -53,7 +53,7 @@ class PulseProcessingSiPM(strax.Plugin):
 
         r = strax.sort_by_time(r)
         strax.zero_out_of_bounds(r)
-        strax.baseline(r, baseline_samples=self.baseline_samples, flip=True)
+        strax.baseline(r, baseline_samples=self.baseline_samples, flip=False)
 
         strax.integrate(r)
 

--- a/amstrax/xams_config.py
+++ b/amstrax/xams_config.py
@@ -134,6 +134,8 @@ class XAMSConfig(Config):
         if value is None:
             if fallback == "xams_default":
                 return DEFAULT_CHANNEL_MAP
+            if fallback == "empty":
+                return []
             raise ValueError(f"No rundoc value found for path '{path}' and run {plugin.run_id}")
         return _as_immutabledict_channel_map(value)
 

--- a/amstrax/xams_config.py
+++ b/amstrax/xams_config.py
@@ -36,33 +36,35 @@ class XAMSConfig(Config):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self._cached_value = None  # Initialize cache for the fetched value
+        self._cache = {}
 
     def fetch(self, plugin):
         """
         Overrides the fetch method to load corrections from JSON or CMT files.
         Handles both 'cmt://' and 'file://' URLs. Otherwise, returns default.
         """
-
-        # Check if the value has already been cached
-        if self._cached_value is not None:
-            return self._cached_value
-
         config_value = plugin.config.get(self.name, self.default)
+        run_id = getattr(plugin, "run_id", None)
 
         # Check if the config is a cmt URL or file URL
         if isinstance(config_value, str):
-            if config_value.startswith("cmt://"):
-                self._cached_value = self._fetch_from_cmt(plugin, config_value)
-            elif config_value.startswith("file://"):
-                self._cached_value = self._fetch_from_file_url(plugin, config_value)
-            elif config_value.startswith("rundoc://"):
-                self._cached_value = self._fetch_from_rundoc_url(plugin, config_value)
-        else:
-            # Cache the default value if no URL is provided
-            self._cached_value = config_value
+            cache_key = (config_value, str(run_id))
+            if cache_key in self._cache:
+                return self._cache[cache_key]
 
-        return self._cached_value
+            if config_value.startswith("cmt://"):
+                value = self._fetch_from_cmt(plugin, config_value)
+            elif config_value.startswith("file://"):
+                value = self._fetch_from_file_url(plugin, config_value)
+            elif config_value.startswith("rundoc://"):
+                value = self._fetch_from_rundoc_url(plugin, config_value)
+            else:
+                value = config_value
+
+            self._cache[cache_key] = value
+            return value
+
+        return config_value
 
     def _fetch_from_cmt(self, plugin, config_value):
         """Fetch correction from a cmt:// URL."""
@@ -89,7 +91,7 @@ class XAMSConfig(Config):
         # Load the correction data (e.g., {'001200': 5500, '001300': 6000})
         correction_data = amstrax.get_correction(correction_file, branch=github_branch)
 
-        value = self.find_correction_value(correction_data, run_id)
+        value = self.find_correction_value(correction_data, run_id, correction_file=correction_file)
 
         return value
 
@@ -103,8 +105,6 @@ class XAMSConfig(Config):
 
         github_branch = query_params.get("github_branch", ["master"])[0]
 
-        self.filename = filename
-
         if not filename:
             raise ValueError(f"Invalid file:// URL, missing filename: {config_value}")
 
@@ -112,7 +112,7 @@ class XAMSConfig(Config):
         correction_data = amstrax.get_correction(filename, branch=github_branch)
 
         # Find the correction value based on the run_id
-        value = self.find_correction_value(correction_data, run_id)
+        value = self.find_correction_value(correction_data, run_id, correction_file=filename)
 
         return value
 
@@ -137,8 +137,8 @@ class XAMSConfig(Config):
             raise ValueError(f"No rundoc value found for path '{path}' and run {plugin.run_id}")
         return _as_immutabledict_channel_map(value)
 
-    def find_correction_value(self, correction_data, run_id):
-        run_id = run_id.zfill(6)  # Ensure run_id is always 6 digits
+    def find_correction_value(self, correction_data, run_id, correction_file=None):
+        run_id = str(run_id).zfill(6)  # Ensure run_id is always 6 digits
         value = None
 
         for run_range in correction_data.keys():
@@ -148,14 +148,14 @@ class XAMSConfig(Config):
                 if end_run == "*":
                     # Only allow * for online corrections
                     # check if there is _dev in the filename
-                    if "_dev" not in self.filename:
+                    if "_dev" not in str(correction_file):
                         raise ValueError(f"Wildcard '*' is only allowed for online corrections")
                     end_run = "999999"  # Treat * as the highest possible run ID
 
                 if start_run == "*":
                     # Only allow * for online corrections
                     # check if there is _dev in the filename
-                    if "_dev" not in self.filename:
+                    if "_dev" not in str(correction_file):
                         raise ValueError(f"Wildcard '*' is only allowed for online corrections")
                     start_run = "000000"
 

--- a/tests/test_corrections.py
+++ b/tests/test_corrections.py
@@ -1,4 +1,6 @@
 import unittest
+from types import SimpleNamespace
+
 import amstrax
 import strax
 
@@ -37,6 +39,52 @@ class TestXamsCorrections(unittest.TestCase):
         # Check that the test2 config works and fetches the correct value
         print(f"Test2 config value: {test2_value}")
         self.assertIsNotNone(test2_value, "Test2 config should not be None")
+
+
+class TestXAMSConfigCaching(unittest.TestCase):
+    def test_rundoc_config_cache_is_run_aware(self):
+        """
+        Rundoc-backed config values must not be reused across run IDs.
+        """
+        cfg = amstrax.XAMSConfig(
+            name="channel_map",
+            default="rundoc://?path=daq_config.channel_map",
+        )
+        calls = []
+        original = amstrax.xams_config.get_rundoc_value
+
+        def fake_get_rundoc_value(run_id, path, detector="xams", default=None):
+            calls.append((str(run_id), path, detector))
+            value = int(run_id)
+            return {"bottom": [value, value], "top": [value + 1, value + 1]}
+
+        try:
+            amstrax.xams_config.get_rundoc_value = fake_get_rundoc_value
+            run_1 = SimpleNamespace(run_id="1", config={})
+            run_2 = SimpleNamespace(run_id="2", config={})
+
+            self.assertEqual(cfg.fetch(run_1)["bottom"], (1, 1))
+            self.assertEqual(cfg.fetch(run_2)["bottom"], (2, 2))
+            self.assertEqual(cfg.fetch(run_1)["bottom"], (1, 1))
+            self.assertEqual(calls, [
+                ("1", "daq_config.channel_map", "xams"),
+                ("2", "daq_config.channel_map", "xams"),
+            ])
+        finally:
+            amstrax.xams_config.get_rundoc_value = original
+
+    def test_online_wildcard_correction_does_not_require_mutable_filename_state(self):
+        cfg = amstrax.XAMSConfig(default=1)
+        correction_data = {"1-*": 42}
+
+        self.assertEqual(
+            cfg.find_correction_value(
+                correction_data,
+                "2",
+                correction_file="example_dev.json",
+            ),
+            42,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Follow-up to #325 that moves detector polarity handling out of `DAQReader` and into processing plugins.

This keeps `raw_records` closer to the DAQ output, adds `raw_records_sipm` to LED record construction, and uses rundoc DAQ registers to avoid flipping SiPM channels in `records_led`.

## Changes

- Add shared DAQ config helpers:
  - `extract_channel_polarity(registers)` for CAEN `1n80` DPP polarity registers.
  - `channels_in_map_group(channel_map, group)` for channel-map ranges.
- Stop `DAQReader` from mutating waveform polarity while producing raw records.
- Stop `context_for_daq_reader` from extracting/passing polarity config that DAQReader no longer uses.
- Add `raw_records_sipm` as an input dependency for `RecordsLED`.
- Make `RecordsLED` fetch `daq_config.registers` from rundoc and undo the historical LED flip for positive-polarity / SiPM channels.
- Set `PulseProcessingSiPM` baseline flipping to `False`, since SiPM raw records are no longer pre-flipped by DAQReader.
- Include the run-aware `XAMSConfig` cache fix needed for safe per-run `rundoc://` values.

## Validation

- No-write Python syntax checks via `ast.parse` for changed Python files.
- `git diff --check` passed.

Full unittest execution is blocked in this local checkout because importing `amstrax` requires missing local dependency `sshtunnel`; full bytecode compile is also constrained by the nearly full filesystem.
