### PR TITLE
Use descriptor-style config for plugins

### DIFF
--- a/amstrax/mini_analysis.py
+++ b/amstrax/mini_analysis.py
@@ -60,7 +60,7 @@ def mini_analysis(
 
                 to_pe = context.config["gain_model"]
                 if isinstance(to_pe, str):
-                    to_pe = strax.Config.evaluate_dry(to_pe, run_id=run_id)
+                    to_pe = amstrax.XAMSConfig.evaluate_dry(to_pe, run_id=run_id)
                 kwargs["to_pe"] = to_pe
 
             # Prepare selection arguments

--- a/amstrax/plugins/events/event_area_per_channel.py
+++ b/amstrax/plugins/events/event_area_per_channel.py
@@ -7,17 +7,16 @@ export, __all__ = strax.exporter()
 
 
 @export
-@strax.takes_config(
-    amstrax.XAMSConfig(
+class EventAreaPerChannel(strax.Plugin):
+    """Simple plugin that provides area per channel for main and alternative S1/S2 in the event."""
+
+    channel_map = amstrax.XAMSConfig(
         name="channel_map",
         default="rundoc://?path=xams_bookkeeping.channel_map&fallback=xams_default",
         track=False,
         type=immutabledict,
         help="immutabledict mapping subdetector to (min, max), loaded from rundoc",
-    ),
-)
-class EventAreaPerChannel(strax.Plugin):
-    """Simple plugin that provides area per channel for main and alternative S1/S2 in the event."""
+    )
 
     depends_on = ("event_basics", "peaks")
     provides = ("event_area_per_channel", "event_n_channel")

--- a/amstrax/plugins/events/event_area_per_channel.py
+++ b/amstrax/plugins/events/event_area_per_channel.py
@@ -11,7 +11,6 @@ class EventAreaPerChannel(strax.Plugin):
     """Simple plugin that provides area per channel for main and alternative S1/S2 in the event."""
 
     channel_map = amstrax.XAMSConfig(
-        name="channel_map",
         default="rundoc://?path=xams_bookkeeping.channel_map&fallback=xams_default",
         track=False,
         type=immutabledict,

--- a/amstrax/plugins/events/event_basics.py
+++ b/amstrax/plugins/events/event_basics.py
@@ -20,32 +20,32 @@ class EventBasics(strax.Plugin):
     """
     __version__ = '1.6'
 
-    electron_drift_velocity = strax.Config(
+    electron_drift_velocity = amstrax.XAMSConfig(
         'electron_drift_velocity',
         default=1.6e-6,
         track=True,
         help='Vertical electron drift velocity in cm/ns (1e4 m/ms)')
-    allow_posts2_s1s = strax.Config(
+    allow_posts2_s1s = amstrax.XAMSConfig(
         'allow_posts2_s1s',
         default=False,
         infer_type=False,
         help="Allow S1s past the main S2 to become the main S1 and S2")
-    force_main_before_alt = strax.Config(
+    force_main_before_alt = amstrax.XAMSConfig(
         'force_main_before_alt',
         default=False,
         infer_type=False,
         help="Make the alternate S1 (and likewise S2) the main S1 if occurs before the main S1.")
-    force_alt_s2_in_max_drift_time = strax.Config(
+    force_alt_s2_in_max_drift_time = amstrax.XAMSConfig(
         'force_alt_s2_in_max_drift_time',
         default=True,
         infer_type=False,
         help="Make sure alt_s2 is in max drift time starting from main S1")
-    event_s1_min_coincidence = strax.Config(
+    event_s1_min_coincidence = amstrax.XAMSConfig(
         'event_s1_min_coincidence',
         default=0,
         infer_type=False,
         help="Event level S1 min coincidence. Should be >= s1_min_coincidence in the peaklet classification")
-    max_drift_length = strax.Config(
+    max_drift_length = amstrax.XAMSConfig(
         'max_drift_length',
         default=amstrax.tpc_z,
         infer_type=False,

--- a/amstrax/plugins/events/event_basics.py
+++ b/amstrax/plugins/events/event_basics.py
@@ -21,32 +21,26 @@ class EventBasics(strax.Plugin):
     __version__ = '1.6'
 
     electron_drift_velocity = amstrax.XAMSConfig(
-        'electron_drift_velocity',
         default=1.6e-6,
         track=True,
         help='Vertical electron drift velocity in cm/ns (1e4 m/ms)')
     allow_posts2_s1s = amstrax.XAMSConfig(
-        'allow_posts2_s1s',
         default=False,
         infer_type=False,
         help="Allow S1s past the main S2 to become the main S1 and S2")
     force_main_before_alt = amstrax.XAMSConfig(
-        'force_main_before_alt',
         default=False,
         infer_type=False,
         help="Make the alternate S1 (and likewise S2) the main S1 if occurs before the main S1.")
     force_alt_s2_in_max_drift_time = amstrax.XAMSConfig(
-        'force_alt_s2_in_max_drift_time',
         default=True,
         infer_type=False,
         help="Make sure alt_s2 is in max drift time starting from main S1")
     event_s1_min_coincidence = amstrax.XAMSConfig(
-        'event_s1_min_coincidence',
         default=0,
         infer_type=False,
         help="Event level S1 min coincidence. Should be >= s1_min_coincidence in the peaklet classification")
     max_drift_length = amstrax.XAMSConfig(
-        'max_drift_length',
         default=amstrax.tpc_z,
         infer_type=False,
         help='Total length of the TPC from the bottom of gate to the top of cathode wires [cm]')

--- a/amstrax/plugins/events/event_basics.py
+++ b/amstrax/plugins/events/event_basics.py
@@ -20,32 +20,32 @@ class EventBasics(strax.Plugin):
     """
     __version__ = '1.6'
 
-    electron_drift_velocity = strax.Option(
+    electron_drift_velocity = strax.Config(
         'electron_drift_velocity',
         default=1.6e-6,
         track=True,
         help='Vertical electron drift velocity in cm/ns (1e4 m/ms)')
-    allow_posts2_s1s = strax.Option(
+    allow_posts2_s1s = strax.Config(
         'allow_posts2_s1s',
         default=False,
         infer_type=False,
         help="Allow S1s past the main S2 to become the main S1 and S2")
-    force_main_before_alt = strax.Option(
+    force_main_before_alt = strax.Config(
         'force_main_before_alt',
         default=False,
         infer_type=False,
         help="Make the alternate S1 (and likewise S2) the main S1 if occurs before the main S1.")
-    force_alt_s2_in_max_drift_time = strax.Option(
+    force_alt_s2_in_max_drift_time = strax.Config(
         'force_alt_s2_in_max_drift_time',
         default=True,
         infer_type=False,
         help="Make sure alt_s2 is in max drift time starting from main S1")
-    event_s1_min_coincidence = strax.Option(
+    event_s1_min_coincidence = strax.Config(
         'event_s1_min_coincidence',
         default=0,
         infer_type=False,
         help="Event level S1 min coincidence. Should be >= s1_min_coincidence in the peaklet classification")
-    max_drift_length = strax.Option(
+    max_drift_length = strax.Config(
         'max_drift_length',
         default=amstrax.tpc_z,
         infer_type=False,

--- a/amstrax/plugins/events/event_basics.py
+++ b/amstrax/plugins/events/event_basics.py
@@ -6,28 +6,6 @@ import amstrax
 export, __all__ = strax.exporter()
 
 
-@strax.takes_config(
-    strax.Option('electron_drift_velocity', default=1.6e-6, track=True,
-                  help='Vertical electron drift velocity in cm/ns (1e4 m/ms)'),
-    strax.Option('allow_posts2_s1s',
-                  default=False, infer_type=False,
-                  help="Allow S1s past the main S2 to become the main S1 and S2"),
-    strax.Option('force_main_before_alt',
-                  default=False, infer_type=False,
-                  help="Make the alternate S1 (and likewise S2) the main S1 if "
-                       "occurs before the main S1."),
-    strax.Option('force_alt_s2_in_max_drift_time',
-                  default=True, infer_type=False,
-                  help="Make sure alt_s2 is in max drift time starting from main S1"),
-    strax.Option('event_s1_min_coincidence',
-                  default=0, infer_type=False,
-                  help="Event level S1 min coincidence. Should be >= s1_min_coincidence "
-                       "in the peaklet classification"),
-    strax.Option('max_drift_length',
-                  default=amstrax.tpc_z, infer_type=False,
-                  help='Total length of the TPC from the bottom of gate to the '
-                       'top of cathode wires [cm]'),
-)
 @export
 class EventBasics(strax.Plugin):
     """
@@ -41,6 +19,37 @@ class EventBasics(strax.Plugin):
     in the time window [main S1 time, main S1 time + max drift time].
     """
     __version__ = '1.6'
+
+    electron_drift_velocity = strax.Option(
+        'electron_drift_velocity',
+        default=1.6e-6,
+        track=True,
+        help='Vertical electron drift velocity in cm/ns (1e4 m/ms)')
+    allow_posts2_s1s = strax.Option(
+        'allow_posts2_s1s',
+        default=False,
+        infer_type=False,
+        help="Allow S1s past the main S2 to become the main S1 and S2")
+    force_main_before_alt = strax.Option(
+        'force_main_before_alt',
+        default=False,
+        infer_type=False,
+        help="Make the alternate S1 (and likewise S2) the main S1 if occurs before the main S1.")
+    force_alt_s2_in_max_drift_time = strax.Option(
+        'force_alt_s2_in_max_drift_time',
+        default=True,
+        infer_type=False,
+        help="Make sure alt_s2 is in max drift time starting from main S1")
+    event_s1_min_coincidence = strax.Option(
+        'event_s1_min_coincidence',
+        default=0,
+        infer_type=False,
+        help="Event level S1 min coincidence. Should be >= s1_min_coincidence in the peaklet classification")
+    max_drift_length = strax.Option(
+        'max_drift_length',
+        default=amstrax.tpc_z,
+        infer_type=False,
+        help='Total length of the TPC from the bottom of gate to the top of cathode wires [cm]')
 
     depends_on = ('events',
                   'peak_basics',
@@ -115,14 +124,6 @@ class EventBasics(strax.Plugin):
         )
 
     def setup(self):
-        
-        self.electron_drift_velocity = self.config['electron_drift_velocity']
-        self.allow_posts2_s1s = self.config['allow_posts2_s1s']
-        self.force_main_before_alt = self.config['force_main_before_alt']
-        self.force_alt_s2_in_max_drift_time = self.config['force_alt_s2_in_max_drift_time']
-        self.event_s1_min_coincidence = self.config['event_s1_min_coincidence']
-        self.max_drift_length = self.config['max_drift_length']
-        
         self.drift_time_max = int(self.max_drift_length / self.electron_drift_velocity)
 
         
@@ -379,4 +380,3 @@ class EventBasics(strax.Plugin):
             res['s2_index'] = s2_idx[0]
             if len(s2_idx) > 1:
                 res['alt_s2_index'] = s2_idx[1]
-

--- a/amstrax/plugins/events/event_coincidences.py
+++ b/amstrax/plugins/events/event_coincidences.py
@@ -14,12 +14,12 @@ class EventCoincidences(strax.OverlapWindowPlugin):
     which allows us to tag the XAMS events that are coincident with the external detector.
     This plugin provides a bool 'is_coinc' that is True if the event is coincident with that external detector.
     """
-    max_delay = strax.Option(
+    max_delay = strax.Config(
         "max_delay",
         default=100,
         help="Maximum allowed time difference between XAMS events and external peaks to count as a match, in ns",
     )
-    absorption_peak_delta = strax.Option(
+    absorption_peak_delta = strax.Config(
         "absorption_peak_delta",
         default=65,
         help="Sets the window as [511 - delta, 511 + delta] in keV for the allowed energies that count as an absorption event of a 511 keV photon in the external detector",

--- a/amstrax/plugins/events/event_coincidences.py
+++ b/amstrax/plugins/events/event_coincidences.py
@@ -14,12 +14,12 @@ class EventCoincidences(strax.OverlapWindowPlugin):
     which allows us to tag the XAMS events that are coincident with the external detector.
     This plugin provides a bool 'is_coinc' that is True if the event is coincident with that external detector.
     """
-    max_delay = strax.Config(
+    max_delay = amstrax.XAMSConfig(
         "max_delay",
         default=100,
         help="Maximum allowed time difference between XAMS events and external peaks to count as a match, in ns",
     )
-    absorption_peak_delta = strax.Config(
+    absorption_peak_delta = amstrax.XAMSConfig(
         "absorption_peak_delta",
         default=65,
         help="Sets the window as [511 - delta, 511 + delta] in keV for the allowed energies that count as an absorption event of a 511 keV photon in the external detector",

--- a/amstrax/plugins/events/event_coincidences.py
+++ b/amstrax/plugins/events/event_coincidences.py
@@ -15,12 +15,10 @@ class EventCoincidences(strax.OverlapWindowPlugin):
     This plugin provides a bool 'is_coinc' that is True if the event is coincident with that external detector.
     """
     max_delay = amstrax.XAMSConfig(
-        "max_delay",
         default=100,
         help="Maximum allowed time difference between XAMS events and external peaks to count as a match, in ns",
     )
     absorption_peak_delta = amstrax.XAMSConfig(
-        "absorption_peak_delta",
         default=65,
         help="Sets the window as [511 - delta, 511 + delta] in keV for the allowed energies that count as an absorption event of a 511 keV photon in the external detector",
     )

--- a/amstrax/plugins/events/event_coincidences.py
+++ b/amstrax/plugins/events/event_coincidences.py
@@ -7,19 +7,6 @@ export, __all__ = strax.exporter()
 
 
 @export
-@strax.takes_config(
-        strax.Option(
-        "max_delay",
-        default=100,
-        help="Maximum allowed time difference between XAMS events and external peaks to count as a match, in ns",
-        ),
-        strax.Option(
-        "absorption_peak_delta",
-        default=65,
-        help="Sets the window as [511 - delta, 511 + delta] in keV for the allowed energies that count as an absorption event of a 511 keV photon in the external detector",
-        ),
-)
-
 class EventCoincidences(strax.OverlapWindowPlugin):
     """
     Some runs are taken with a na-22 source. This source emits two 511keV photons in exactly opposite directions.
@@ -27,6 +14,16 @@ class EventCoincidences(strax.OverlapWindowPlugin):
     which allows us to tag the XAMS events that are coincident with the external detector.
     This plugin provides a bool 'is_coinc' that is True if the event is coincident with that external detector.
     """
+    max_delay = strax.Option(
+        "max_delay",
+        default=100,
+        help="Maximum allowed time difference between XAMS events and external peaks to count as a match, in ns",
+    )
+    absorption_peak_delta = strax.Option(
+        "absorption_peak_delta",
+        default=65,
+        help="Sets the window as [511 - delta, 511 + delta] in keV for the allowed energies that count as an absorption event of a 511 keV photon in the external detector",
+    )
 
     provides = ('event_coincidences',)
     depends_on = ('event_basics', 'peaks_ext',)

--- a/amstrax/plugins/events/event_positions.py
+++ b/amstrax/plugins/events/event_positions.py
@@ -24,19 +24,15 @@ class EventPositions(strax.Plugin):
     __version__ = '1.1.20'
 
     default_reconstruction_algorithm = amstrax.XAMSConfig(
-        'default_reconstruction_algorithm',
         default=DEFAULT_POSREC_ALGO,
         help="default reconstruction algorithm that provides (x,y)")
     drift_time_gate = amstrax.XAMSConfig(
-        'drift_time_gate',
         default=3000,
         help='Drift time belonging to the gate in ns')
     drift_time_cathode = amstrax.XAMSConfig(
-        'drift_time_cathode',
         default=39500,
         help='Drift time belonging to the cathode in ns')
     gate_cathode_distance = amstrax.XAMSConfig(
-        'gate_cathode_distance',
         default=50.5,
         help='Distance between gate and cathode in mm')
 

--- a/amstrax/plugins/events/event_positions.py
+++ b/amstrax/plugins/events/event_positions.py
@@ -23,19 +23,19 @@ class EventPositions(strax.Plugin):
 
     __version__ = '1.1.20'
 
-    default_reconstruction_algorithm = strax.Config(
+    default_reconstruction_algorithm = amstrax.XAMSConfig(
         'default_reconstruction_algorithm',
         default=DEFAULT_POSREC_ALGO,
         help="default reconstruction algorithm that provides (x,y)")
-    drift_time_gate = strax.Config(
+    drift_time_gate = amstrax.XAMSConfig(
         'drift_time_gate',
         default=3000,
         help='Drift time belonging to the gate in ns')
-    drift_time_cathode = strax.Config(
+    drift_time_cathode = amstrax.XAMSConfig(
         'drift_time_cathode',
         default=39500,
         help='Drift time belonging to the cathode in ns')
-    gate_cathode_distance = strax.Config(
+    gate_cathode_distance = amstrax.XAMSConfig(
         'gate_cathode_distance',
         default=50.5,
         help='Distance between gate and cathode in mm')

--- a/amstrax/plugins/events/event_positions.py
+++ b/amstrax/plugins/events/event_positions.py
@@ -10,21 +10,6 @@ export, __all__ = strax.exporter()
 
 
 @export
-@strax.takes_config(
-    strax.Option('default_reconstruction_algorithm',
-                 default=DEFAULT_POSREC_ALGO,
-                 help="default reconstruction algorithm that provides (x,y)"),
-    strax.Option('drift_time_gate',
-                 default=3000,
-                 help='Drift time belonging to the gate in ns'),
-    strax.Option('drift_time_cathode',
-                 default=39500,
-                 help='Drift time belonging to the cathode in ns'),
-    strax.Option('gate_cathode_distance',
-                 default=50.5,
-                 help='Distance between gate and cathode in mm'),    
-)
-
 class EventPositions(strax.Plugin):
     """
     Computes the observed and corrected position for the main S1/S2
@@ -38,6 +23,22 @@ class EventPositions(strax.Plugin):
 
     __version__ = '1.1.20'
 
+    default_reconstruction_algorithm = strax.Option(
+        'default_reconstruction_algorithm',
+        default=DEFAULT_POSREC_ALGO,
+        help="default reconstruction algorithm that provides (x,y)")
+    drift_time_gate = strax.Option(
+        'drift_time_gate',
+        default=3000,
+        help='Drift time belonging to the gate in ns')
+    drift_time_cathode = strax.Option(
+        'drift_time_cathode',
+        default=39500,
+        help='Drift time belonging to the cathode in ns')
+    gate_cathode_distance = strax.Option(
+        'gate_cathode_distance',
+        default=50.5,
+        help='Distance between gate and cathode in mm')
 
     def infer_dtype(self):
         dtype = []
@@ -54,13 +55,6 @@ class EventPositions(strax.Plugin):
         
         return dtype + strax.time_fields
 
-    def setup(self):
-
-        self.default_reconstruction_algorithm = self.config['default_reconstruction_algorithm']
-        self.drift_time_gate = self.config['drift_time_gate']
-        self.drift_time_cathode = self.config['drift_time_cathode']
-        self.gate_cathode_distance = self.config['gate_cathode_distance']
-        
     def compute(self, events):
 
         result = {'time': events['time'],

--- a/amstrax/plugins/events/event_positions.py
+++ b/amstrax/plugins/events/event_positions.py
@@ -23,19 +23,19 @@ class EventPositions(strax.Plugin):
 
     __version__ = '1.1.20'
 
-    default_reconstruction_algorithm = strax.Option(
+    default_reconstruction_algorithm = strax.Config(
         'default_reconstruction_algorithm',
         default=DEFAULT_POSREC_ALGO,
         help="default reconstruction algorithm that provides (x,y)")
-    drift_time_gate = strax.Option(
+    drift_time_gate = strax.Config(
         'drift_time_gate',
         default=3000,
         help='Drift time belonging to the gate in ns')
-    drift_time_cathode = strax.Option(
+    drift_time_cathode = strax.Config(
         'drift_time_cathode',
         default=39500,
         help='Drift time belonging to the cathode in ns')
-    gate_cathode_distance = strax.Option(
+    gate_cathode_distance = strax.Config(
         'gate_cathode_distance',
         default=50.5,
         help='Distance between gate and cathode in mm')

--- a/amstrax/plugins/events/events.py
+++ b/amstrax/plugins/events/events.py
@@ -6,13 +6,13 @@ export, __all__ = strax.exporter()
 @export
 class Events(strax.OverlapWindowPlugin):
     trigger_min_area = amstrax.XAMSConfig(
-        'trigger_min_area', default=10,
+        default=10,
         help='Peaks must have more area (PE) than this to cause events')
     left_event_extension = amstrax.XAMSConfig(
-        'left_event_extension', default=int(5e5),
+        default=int(5e5),
         help='Extend events this many ns to the left from each triggering peak')
     right_event_extension = amstrax.XAMSConfig(
-        'right_event_extension', default=int(5e4),
+        default=int(5e4),
         help='Extend events this many ns to the right from each triggering peak')
 
     depends_on = ['peaks', 

--- a/amstrax/plugins/events/events.py
+++ b/amstrax/plugins/events/events.py
@@ -5,13 +5,13 @@ export, __all__ = strax.exporter()
 
 @export
 class Events(strax.OverlapWindowPlugin):
-    trigger_min_area = strax.Config(
+    trigger_min_area = amstrax.XAMSConfig(
         'trigger_min_area', default=10,
         help='Peaks must have more area (PE) than this to cause events')
-    left_event_extension = strax.Config(
+    left_event_extension = amstrax.XAMSConfig(
         'left_event_extension', default=int(5e5),
         help='Extend events this many ns to the left from each triggering peak')
-    right_event_extension = strax.Config(
+    right_event_extension = amstrax.XAMSConfig(
         'right_event_extension', default=int(5e4),
         help='Extend events this many ns to the right from each triggering peak')
 

--- a/amstrax/plugins/events/events.py
+++ b/amstrax/plugins/events/events.py
@@ -1,3 +1,4 @@
+import amstrax
 import numba
 import numpy as np
 import strax

--- a/amstrax/plugins/events/events.py
+++ b/amstrax/plugins/events/events.py
@@ -4,18 +4,17 @@ import strax
 export, __all__ = strax.exporter()
 
 @export
-@strax.takes_config(
-    strax.Option('trigger_min_area', default=10,
-                 help='Peaks must have more area (PE) than this to '
-                      'cause events'),
-    strax.Option('left_event_extension', default=int(5e5),
-                 help='Extend events this many ns to the left from each '
-                      'triggering peak'),
-    strax.Option('right_event_extension', default=int(5e4),
-                 help='Extend events this many ns to the right from each '
-                      'triggering peak'),
-)
 class Events(strax.OverlapWindowPlugin):
+    trigger_min_area = strax.Option(
+        'trigger_min_area', default=10,
+        help='Peaks must have more area (PE) than this to cause events')
+    left_event_extension = strax.Option(
+        'left_event_extension', default=int(5e5),
+        help='Extend events this many ns to the left from each triggering peak')
+    right_event_extension = strax.Option(
+        'right_event_extension', default=int(5e4),
+        help='Extend events this many ns to the right from each triggering peak')
+
     depends_on = ['peaks', 
                   'peak_basics',
                   ]
@@ -67,4 +66,3 @@ class Events(strax.OverlapWindowPlugin):
         self.events_seen += len(result)
 
         return result
-

--- a/amstrax/plugins/events/events.py
+++ b/amstrax/plugins/events/events.py
@@ -5,13 +5,13 @@ export, __all__ = strax.exporter()
 
 @export
 class Events(strax.OverlapWindowPlugin):
-    trigger_min_area = strax.Option(
+    trigger_min_area = strax.Config(
         'trigger_min_area', default=10,
         help='Peaks must have more area (PE) than this to cause events')
-    left_event_extension = strax.Option(
+    left_event_extension = strax.Config(
         'left_event_extension', default=int(5e5),
         help='Extend events this many ns to the left from each triggering peak')
-    right_event_extension = strax.Option(
+    right_event_extension = strax.Config(
         'right_event_extension', default=int(5e4),
         help='Extend events this many ns to the right from each triggering peak')
 

--- a/amstrax/plugins/led_calibration/led_calibration.py
+++ b/amstrax/plugins/led_calibration/led_calibration.py
@@ -1,3 +1,4 @@
+import amstrax
 from immutabledict import immutabledict
 import strax
 import numba

--- a/amstrax/plugins/led_calibration/led_calibration.py
+++ b/amstrax/plugins/led_calibration/led_calibration.py
@@ -21,12 +21,12 @@ class LEDCalibration(strax.Plugin):
         - amplitudeNOISE: amplitude of the LED on run in a window far
           from the signal one.
     """
-    led_window = strax.Config(
+    led_window = amstrax.XAMSConfig(
         "led_window",
         default=(80, 110),
         help="Window (samples) where we expect the signal in LED calibration",
     )
-    noise_window = strax.Config(
+    noise_window = amstrax.XAMSConfig(
         "noise_window", default=(0, 10), help="Window (samples) to analysis the noise"
     )
 

--- a/amstrax/plugins/led_calibration/led_calibration.py
+++ b/amstrax/plugins/led_calibration/led_calibration.py
@@ -7,16 +7,6 @@ export, __all__ = strax.exporter()
 
 
 @export
-@strax.takes_config(
-    strax.Option(
-        "led_window",
-        default=(80, 110),
-        help="Window (samples) where we expect the signal in LED calibration",
-    ),
-    strax.Option(
-        "noise_window", default=(0, 10), help="Window (samples) to analysis the noise"
-    ),
-)
 class LEDCalibration(strax.Plugin):
     """
     Preliminary version, several parameters to set during commissioning.
@@ -31,6 +21,14 @@ class LEDCalibration(strax.Plugin):
         - amplitudeNOISE: amplitude of the LED on run in a window far
           from the signal one.
     """
+    led_window = strax.Option(
+        "led_window",
+        default=(80, 110),
+        help="Window (samples) where we expect the signal in LED calibration",
+    )
+    noise_window = strax.Option(
+        "noise_window", default=(0, 10), help="Window (samples) to analysis the noise"
+    )
 
     __version__ = "1.0.0"
 
@@ -49,10 +47,6 @@ class LEDCalibration(strax.Plugin):
         ("dt", np.int16, "Time resolution in ns"),
         ("length", np.int32, "Length of the interval in samples"),
     ]
-
-    def setup(self):
-        self.led_window = self.config["led_window"]
-        self.noise_window = self.config["noise_window"]
 
     def compute(self, records_led):
         """

--- a/amstrax/plugins/led_calibration/led_calibration.py
+++ b/amstrax/plugins/led_calibration/led_calibration.py
@@ -22,12 +22,11 @@ class LEDCalibration(strax.Plugin):
           from the signal one.
     """
     led_window = amstrax.XAMSConfig(
-        "led_window",
         default=(80, 110),
         help="Window (samples) where we expect the signal in LED calibration",
     )
     noise_window = amstrax.XAMSConfig(
-        "noise_window", default=(0, 10), help="Window (samples) to analysis the noise"
+        default=(0, 10), help="Window (samples) to analysis the noise"
     )
 
     __version__ = "1.0.0"

--- a/amstrax/plugins/led_calibration/led_calibration.py
+++ b/amstrax/plugins/led_calibration/led_calibration.py
@@ -21,12 +21,12 @@ class LEDCalibration(strax.Plugin):
         - amplitudeNOISE: amplitude of the LED on run in a window far
           from the signal one.
     """
-    led_window = strax.Option(
+    led_window = strax.Config(
         "led_window",
         default=(80, 110),
         help="Window (samples) where we expect the signal in LED calibration",
     )
-    noise_window = strax.Option(
+    noise_window = strax.Config(
         "noise_window", default=(0, 10), help="Window (samples) to analysis the noise"
     )
 

--- a/amstrax/plugins/led_calibration/records_led.py
+++ b/amstrax/plugins/led_calibration/records_led.py
@@ -13,20 +13,20 @@ class RecordsLED(strax.Plugin):
 
     __version__ = '1.1.0'
 
-    record_length = strax.Config(
+    record_length = amstrax.XAMSConfig(
         "record_length",
         default=110,
         track=False,
         type=int,
         help="Number of samples per raw_record",
     )
-    baseline_window = strax.Config(
+    baseline_window = amstrax.XAMSConfig(
         "baseline_window",
         default=(0, 50),
         infer_type=False,
         help="Window (samples) for baseline calculation.",
     )
-    n_records_per_pulse = strax.Config(
+    n_records_per_pulse = amstrax.XAMSConfig(
         "n_records_per_pulse",
         default=2,
         type=int,

--- a/amstrax/plugins/led_calibration/records_led.py
+++ b/amstrax/plugins/led_calibration/records_led.py
@@ -6,34 +6,39 @@ import amstrax
 export, __all__ = strax.exporter()
 
 @export
-@strax.takes_config(
-
-    strax.Option('record_length', default=110, track=False, type=int,
-                 help="Number of samples per raw_record"),
-
-    strax.Option('baseline_window',
-        default=(0, 50), infer_type=False,
-        help="Window (samples) for baseline calculation."),
-
-    strax.Option('n_records_per_pulse',
-        default=2, type=int,
-        help="how many samples per pulse"),
-
-    amstrax.XAMSConfig(
-        name="daq_registers",
-        default="rundoc://?path=daq_config.registers&fallback=empty",
-        track=False,
-        infer_type=False,
-        help="DAQ register list from rundoc, used to infer channel polarity.",
-    ),
-
-)
 class RecordsLED(strax.Plugin):
     """
     Carlo needs to explain
     """
 
     __version__ = '1.1.0'
+
+    record_length = strax.Option(
+        "record_length",
+        default=110,
+        track=False,
+        type=int,
+        help="Number of samples per raw_record",
+    )
+    baseline_window = strax.Option(
+        "baseline_window",
+        default=(0, 50),
+        infer_type=False,
+        help="Window (samples) for baseline calculation.",
+    )
+    n_records_per_pulse = strax.Option(
+        "n_records_per_pulse",
+        default=2,
+        type=int,
+        help="how many samples per pulse",
+    )
+    daq_registers = amstrax.XAMSConfig(
+        name="daq_registers",
+        default="rundoc://?path=daq_config.registers&fallback=empty",
+        track=False,
+        infer_type=False,
+        help="DAQ register list from rundoc, used to infer channel polarity.",
+    )
 
     depends_on = ('raw_records', 'raw_records_sipm')
     data_kind = 'records_led'
@@ -46,11 +51,7 @@ class RecordsLED(strax.Plugin):
   
     def setup(self):
 
-        self.record_length = self.config['record_length']
-        self.baseline_window = self.config['baseline_window']
-        self.n_records_per_pulse = self.config['n_records_per_pulse']
-        daq_registers = self.takes_config["daq_registers"].__get__(self)
-        self.channel_polarity = amstrax.extract_channel_polarity(daq_registers)
+        self.channel_polarity = amstrax.extract_channel_polarity(self.daq_registers)
 
     def infer_dtype(self):
 

--- a/amstrax/plugins/led_calibration/records_led.py
+++ b/amstrax/plugins/led_calibration/records_led.py
@@ -13,20 +13,20 @@ class RecordsLED(strax.Plugin):
 
     __version__ = '1.1.0'
 
-    record_length = strax.Option(
+    record_length = strax.Config(
         "record_length",
         default=110,
         track=False,
         type=int,
         help="Number of samples per raw_record",
     )
-    baseline_window = strax.Option(
+    baseline_window = strax.Config(
         "baseline_window",
         default=(0, 50),
         infer_type=False,
         help="Window (samples) for baseline calculation.",
     )
-    n_records_per_pulse = strax.Option(
+    n_records_per_pulse = strax.Config(
         "n_records_per_pulse",
         default=2,
         type=int,

--- a/amstrax/plugins/led_calibration/records_led.py
+++ b/amstrax/plugins/led_calibration/records_led.py
@@ -14,26 +14,22 @@ class RecordsLED(strax.Plugin):
     __version__ = '1.1.0'
 
     record_length = amstrax.XAMSConfig(
-        "record_length",
         default=110,
         track=False,
         type=int,
         help="Number of samples per raw_record",
     )
     baseline_window = amstrax.XAMSConfig(
-        "baseline_window",
         default=(0, 50),
         infer_type=False,
         help="Window (samples) for baseline calculation.",
     )
     n_records_per_pulse = amstrax.XAMSConfig(
-        "n_records_per_pulse",
         default=2,
         type=int,
         help="how many samples per pulse",
     )
     daq_registers = amstrax.XAMSConfig(
-        name="daq_registers",
         default="rundoc://?path=daq_config.registers&fallback=empty",
         track=False,
         infer_type=False,

--- a/amstrax/plugins/peaks/peak_basics.py
+++ b/amstrax/plugins/peaks/peak_basics.py
@@ -18,32 +18,30 @@ class PeakBasics(strax.Plugin):
     rechunk_on_save = False
     __version__ = "2.1"
     channel_map = amstrax.XAMSConfig(
-        name="channel_map",
         default="rundoc://?path=xams_bookkeeping.channel_map&fallback=xams_default",
         type=immutabledict,
         track=False,
         help="Map of channel groups loaded from rundoc xams_bookkeeping.channel_map",
     )
     check_peak_sum_area_rtol = amstrax.XAMSConfig(
-        "check_peak_sum_area_rtol",
         default=1e-4,
         help="Check if the area of the sum-wf is the same as the total area"
         " (if the area of the peak is positively defined)."
         " Set to None to disable.",
     )
-    s1_min_width = amstrax.XAMSConfig('s1_min_width', default=10, help="Minimum (IQR) width of S1s")
-    s1_max_width = amstrax.XAMSConfig('s1_max_width', default=225, help="Maximum (IQR) width of S1s")
-    s1_min_area = amstrax.XAMSConfig('s1_min_area', default=10, help="Minimum area (PE) for S1s")
-    s2_min_area = amstrax.XAMSConfig('s2_min_area', default=10, help="Minimum area (PE) for S2s")
-    s2_min_width = amstrax.XAMSConfig('s2_min_width', default=225, help="Minimum width for S2s")
+    s1_min_width = amstrax.XAMSConfig(default=10, help="Minimum (IQR) width of S1s")
+    s1_max_width = amstrax.XAMSConfig(default=225, help="Maximum (IQR) width of S1s")
+    s1_min_area = amstrax.XAMSConfig(default=10, help="Minimum area (PE) for S1s")
+    s2_min_area = amstrax.XAMSConfig(default=10, help="Minimum area (PE) for S2s")
+    s2_min_width = amstrax.XAMSConfig(default=225, help="Minimum width for S2s")
     s1_min_channels = amstrax.XAMSConfig(
-        's1_min_channels', default=5, help="Minimum number of channels for S1s")
+        default=5, help="Minimum number of channels for S1s")
     s2_min_channels = amstrax.XAMSConfig(
-        's2_min_channels', default=5, help="Minimum number of channels for S2s")
+        default=5, help="Minimum number of channels for S2s")
     s2_min_area_fraction_top = amstrax.XAMSConfig(
-        's2_min_area_fraction_top', default=0, help="Minimum area fraction top for S2s")
+        default=0, help="Minimum area fraction top for S2s")
     s1_max_area_fraction_top = amstrax.XAMSConfig(
-        's1_max_area_fraction_top', default=.2, help="Maximum area fraction top for S1s")
+        default=.2, help="Maximum area fraction top for S1s")
     dtype = [
         (('Start time of the peak (ns since unix epoch)',
           'time'), np.int64),

--- a/amstrax/plugins/peaks/peak_basics.py
+++ b/amstrax/plugins/peaks/peak_basics.py
@@ -24,25 +24,25 @@ class PeakBasics(strax.Plugin):
         track=False,
         help="Map of channel groups loaded from rundoc xams_bookkeeping.channel_map",
     )
-    check_peak_sum_area_rtol = strax.Config(
+    check_peak_sum_area_rtol = amstrax.XAMSConfig(
         "check_peak_sum_area_rtol",
         default=1e-4,
         help="Check if the area of the sum-wf is the same as the total area"
         " (if the area of the peak is positively defined)."
         " Set to None to disable.",
     )
-    s1_min_width = strax.Config('s1_min_width', default=10, help="Minimum (IQR) width of S1s")
-    s1_max_width = strax.Config('s1_max_width', default=225, help="Maximum (IQR) width of S1s")
-    s1_min_area = strax.Config('s1_min_area', default=10, help="Minimum area (PE) for S1s")
-    s2_min_area = strax.Config('s2_min_area', default=10, help="Minimum area (PE) for S2s")
-    s2_min_width = strax.Config('s2_min_width', default=225, help="Minimum width for S2s")
-    s1_min_channels = strax.Config(
+    s1_min_width = amstrax.XAMSConfig('s1_min_width', default=10, help="Minimum (IQR) width of S1s")
+    s1_max_width = amstrax.XAMSConfig('s1_max_width', default=225, help="Maximum (IQR) width of S1s")
+    s1_min_area = amstrax.XAMSConfig('s1_min_area', default=10, help="Minimum area (PE) for S1s")
+    s2_min_area = amstrax.XAMSConfig('s2_min_area', default=10, help="Minimum area (PE) for S2s")
+    s2_min_width = amstrax.XAMSConfig('s2_min_width', default=225, help="Minimum width for S2s")
+    s1_min_channels = amstrax.XAMSConfig(
         's1_min_channels', default=5, help="Minimum number of channels for S1s")
-    s2_min_channels = strax.Config(
+    s2_min_channels = amstrax.XAMSConfig(
         's2_min_channels', default=5, help="Minimum number of channels for S2s")
-    s2_min_area_fraction_top = strax.Config(
+    s2_min_area_fraction_top = amstrax.XAMSConfig(
         's2_min_area_fraction_top', default=0, help="Minimum area fraction top for S2s")
-    s1_max_area_fraction_top = strax.Config(
+    s1_max_area_fraction_top = amstrax.XAMSConfig(
         's1_max_area_fraction_top', default=.2, help="Maximum area fraction top for S1s")
     dtype = [
         (('Start time of the peak (ns since unix epoch)',

--- a/amstrax/plugins/peaks/peak_basics.py
+++ b/amstrax/plugins/peaks/peak_basics.py
@@ -9,67 +9,6 @@ export, __all__ = strax.exporter()
 
 # For n_competing, which is temporarily added to PeakBasics
 @export
-@strax.takes_config(
-    amstrax.XAMSConfig(
-        name="channel_map",
-        default="rundoc://?path=xams_bookkeeping.channel_map&fallback=xams_default",
-        type=immutabledict,
-        track=False,
-        help="Map of channel groups loaded from rundoc xams_bookkeeping.channel_map",
-    ),
-    strax.Option(
-        "check_peak_sum_area_rtol",
-        default=1e-4,
-        help="Check if the area of the sum-wf is the same as the total area"
-        " (if the area of the peak is positively defined)."
-        " Set to None to disable.",
-    ),
-    strax.Option(
-      's1_min_width', 
-      default=10,
-      help="Minimum (IQR) width of S1s"
-    ),
-    strax.Option(
-      's1_max_width',
-      default=225,
-      help="Maximum (IQR) width of S1s"
-    ),
-    strax.Option(
-      's1_min_area',
-      default=10,
-      help="Minimum area (PE) for S1s"
-    ),
-    strax.Option(
-      's2_min_area',
-      default=10,
-      help="Minimum area (PE) for S2s"
-    ),
-    strax.Option(
-      's2_min_width',
-      default=225,
-      help="Minimum width for S2s"
-    ),
-    strax.Option(
-      's1_min_channels',
-      default=5,
-      help="Minimum number of channels for S1s"
-    ),
-    strax.Option(
-      's2_min_channels',
-      default=5,
-      help="Minimum number of channels for S2s"
-    ),
-    strax.Option(
-      's2_min_area_fraction_top',
-      default=0,
-      help="Minimum area fraction top for S2s"
-    ),
-    strax.Option(
-      's1_max_area_fraction_top',
-      default=.2,
-      help="Maximum area fraction top for S1s"
-    ),
-)
 class PeakBasics(strax.Plugin):
     provides = ("peak_basics",)
     depends_on = ("peaks", )
@@ -78,6 +17,33 @@ class PeakBasics(strax.Plugin):
     parallel = "False"
     rechunk_on_save = False
     __version__ = "2.1"
+    channel_map = amstrax.XAMSConfig(
+        name="channel_map",
+        default="rundoc://?path=xams_bookkeeping.channel_map&fallback=xams_default",
+        type=immutabledict,
+        track=False,
+        help="Map of channel groups loaded from rundoc xams_bookkeeping.channel_map",
+    )
+    check_peak_sum_area_rtol = strax.Option(
+        "check_peak_sum_area_rtol",
+        default=1e-4,
+        help="Check if the area of the sum-wf is the same as the total area"
+        " (if the area of the peak is positively defined)."
+        " Set to None to disable.",
+    )
+    s1_min_width = strax.Option('s1_min_width', default=10, help="Minimum (IQR) width of S1s")
+    s1_max_width = strax.Option('s1_max_width', default=225, help="Maximum (IQR) width of S1s")
+    s1_min_area = strax.Option('s1_min_area', default=10, help="Minimum area (PE) for S1s")
+    s2_min_area = strax.Option('s2_min_area', default=10, help="Minimum area (PE) for S2s")
+    s2_min_width = strax.Option('s2_min_width', default=225, help="Minimum width for S2s")
+    s1_min_channels = strax.Option(
+        's1_min_channels', default=5, help="Minimum number of channels for S1s")
+    s2_min_channels = strax.Option(
+        's2_min_channels', default=5, help="Minimum number of channels for S2s")
+    s2_min_area_fraction_top = strax.Option(
+        's2_min_area_fraction_top', default=0, help="Minimum area fraction top for S2s")
+    s1_max_area_fraction_top = strax.Option(
+        's1_max_area_fraction_top', default=.2, help="Maximum area fraction top for S1s")
     dtype = [
         (('Start time of the peak (ns since unix epoch)',
           'time'), np.int64),
@@ -135,7 +101,7 @@ class PeakBasics(strax.Plugin):
 
         # channel map is something like this
         # {'bottom': (0, 0), 'top': (1, 4), 'aqmon': (40, 40)}
-        channel_map = self.config['channel_map']
+        channel_map = self.channel_map
         top_pmt_indices = channel_map['top']
         bottom_pmt_indices = channel_map['bottom']
 

--- a/amstrax/plugins/peaks/peak_basics.py
+++ b/amstrax/plugins/peaks/peak_basics.py
@@ -24,25 +24,25 @@ class PeakBasics(strax.Plugin):
         track=False,
         help="Map of channel groups loaded from rundoc xams_bookkeeping.channel_map",
     )
-    check_peak_sum_area_rtol = strax.Option(
+    check_peak_sum_area_rtol = strax.Config(
         "check_peak_sum_area_rtol",
         default=1e-4,
         help="Check if the area of the sum-wf is the same as the total area"
         " (if the area of the peak is positively defined)."
         " Set to None to disable.",
     )
-    s1_min_width = strax.Option('s1_min_width', default=10, help="Minimum (IQR) width of S1s")
-    s1_max_width = strax.Option('s1_max_width', default=225, help="Maximum (IQR) width of S1s")
-    s1_min_area = strax.Option('s1_min_area', default=10, help="Minimum area (PE) for S1s")
-    s2_min_area = strax.Option('s2_min_area', default=10, help="Minimum area (PE) for S2s")
-    s2_min_width = strax.Option('s2_min_width', default=225, help="Minimum width for S2s")
-    s1_min_channels = strax.Option(
+    s1_min_width = strax.Config('s1_min_width', default=10, help="Minimum (IQR) width of S1s")
+    s1_max_width = strax.Config('s1_max_width', default=225, help="Maximum (IQR) width of S1s")
+    s1_min_area = strax.Config('s1_min_area', default=10, help="Minimum area (PE) for S1s")
+    s2_min_area = strax.Config('s2_min_area', default=10, help="Minimum area (PE) for S2s")
+    s2_min_width = strax.Config('s2_min_width', default=225, help="Minimum width for S2s")
+    s1_min_channels = strax.Config(
         's1_min_channels', default=5, help="Minimum number of channels for S1s")
-    s2_min_channels = strax.Option(
+    s2_min_channels = strax.Config(
         's2_min_channels', default=5, help="Minimum number of channels for S2s")
-    s2_min_area_fraction_top = strax.Option(
+    s2_min_area_fraction_top = strax.Config(
         's2_min_area_fraction_top', default=0, help="Minimum area fraction top for S2s")
-    s1_max_area_fraction_top = strax.Option(
+    s1_max_area_fraction_top = strax.Config(
         's1_max_area_fraction_top', default=.2, help="Maximum area fraction top for S1s")
     dtype = [
         (('Start time of the peak (ns since unix epoch)',

--- a/amstrax/plugins/peaks/peak_coincidences.py
+++ b/amstrax/plugins/peaks/peak_coincidences.py
@@ -12,12 +12,12 @@ class PeakCoincidences(strax.OverlapWindowPlugin):
     which allows us to tag the XAMS peaks that are coincident with the external detector.
     This plugin provides a bool 'is_coinc' that is True if the peak is coincident with that external detector.
     """
-    max_delay = strax.Option(
+    max_delay = strax.Config(
         "max_delay",
         default=100,
         help="Maximum allowed time difference between XAMS peaks and external peaks to count as a match, in ns",
     )
-    absorption_peak_delta = strax.Option(
+    absorption_peak_delta = strax.Config(
         "absorption_peak_delta",
         default=65,
         help="Sets the window as [511 - delta, 511 + delta] in keV for the allowed energies that count as an absorption event of a 511 keV photon in the external detector",

--- a/amstrax/plugins/peaks/peak_coincidences.py
+++ b/amstrax/plugins/peaks/peak_coincidences.py
@@ -1,3 +1,4 @@
+import amstrax
 import numba
 import numpy as np
 import strax

--- a/amstrax/plugins/peaks/peak_coincidences.py
+++ b/amstrax/plugins/peaks/peak_coincidences.py
@@ -12,12 +12,12 @@ class PeakCoincidences(strax.OverlapWindowPlugin):
     which allows us to tag the XAMS peaks that are coincident with the external detector.
     This plugin provides a bool 'is_coinc' that is True if the peak is coincident with that external detector.
     """
-    max_delay = strax.Config(
+    max_delay = amstrax.XAMSConfig(
         "max_delay",
         default=100,
         help="Maximum allowed time difference between XAMS peaks and external peaks to count as a match, in ns",
     )
-    absorption_peak_delta = strax.Config(
+    absorption_peak_delta = amstrax.XAMSConfig(
         "absorption_peak_delta",
         default=65,
         help="Sets the window as [511 - delta, 511 + delta] in keV for the allowed energies that count as an absorption event of a 511 keV photon in the external detector",

--- a/amstrax/plugins/peaks/peak_coincidences.py
+++ b/amstrax/plugins/peaks/peak_coincidences.py
@@ -5,18 +5,6 @@ from immutabledict import immutabledict
 export, __all__ = strax.exporter()
 
 @export
-@strax.takes_config(
-        strax.Option(
-        "max_delay",
-        default=100,
-        help="Maximum allowed time difference between XAMS peaks and external peaks to count as a match, in ns",
-        ),
-        strax.Option(
-        "absorption_peak_delta",
-        default=65,
-        help="Sets the window as [511 - delta, 511 + delta] in keV for the allowed energies that count as an absorption event of a 511 keV photon in the external detector",
-        ),
-)
 class PeakCoincidences(strax.OverlapWindowPlugin):
     """
     Some runs are taken with a na-22 source. This source emits two 511keV photons in exactly opposite directions.
@@ -24,6 +12,16 @@ class PeakCoincidences(strax.OverlapWindowPlugin):
     which allows us to tag the XAMS peaks that are coincident with the external detector.
     This plugin provides a bool 'is_coinc' that is True if the peak is coincident with that external detector.
     """
+    max_delay = strax.Option(
+        "max_delay",
+        default=100,
+        help="Maximum allowed time difference between XAMS peaks and external peaks to count as a match, in ns",
+    )
+    absorption_peak_delta = strax.Option(
+        "absorption_peak_delta",
+        default=65,
+        help="Sets the window as [511 - delta, 511 + delta] in keV for the allowed energies that count as an absorption event of a 511 keV photon in the external detector",
+    )
 
     provides = ('peak_coincidences',)
     depends_on = ('peaks', 'peaks_ext',)

--- a/amstrax/plugins/peaks/peak_coincidences.py
+++ b/amstrax/plugins/peaks/peak_coincidences.py
@@ -13,12 +13,10 @@ class PeakCoincidences(strax.OverlapWindowPlugin):
     This plugin provides a bool 'is_coinc' that is True if the peak is coincident with that external detector.
     """
     max_delay = amstrax.XAMSConfig(
-        "max_delay",
         default=100,
         help="Maximum allowed time difference between XAMS peaks and external peaks to count as a match, in ns",
     )
     absorption_peak_delta = amstrax.XAMSConfig(
-        "absorption_peak_delta",
         default=65,
         help="Sets the window as [511 - delta, 511 + delta] in keV for the allowed energies that count as an absorption event of a 511 keV photon in the external detector",
     )

--- a/amstrax/plugins/peaks/peak_positions.py
+++ b/amstrax/plugins/peaks/peak_positions.py
@@ -37,14 +37,12 @@ class PeakPositions(strax.Plugin):
     ]
 
     channel_map = amstrax.XAMSConfig(
-        name="channel_map",
         default="rundoc://?path=xams_bookkeeping.channel_map&fallback=xams_default",
         type=immutabledict,
         track=False,
         help="Map of channel groups loaded from rundoc xams_bookkeeping.channel_map",
     )
     default_reconstruction_algorithm = amstrax.XAMSConfig(
-        'default_reconstruction_algorithm',
         default=DEFAULT_POSREC_ALGO,
         help="default reconstruction algorithm that provides (x,y)"
     )

--- a/amstrax/plugins/peaks/peak_positions.py
+++ b/amstrax/plugins/peaks/peak_positions.py
@@ -9,19 +9,6 @@ export, __all__ = strax.exporter()
 DEFAULT_POSREC_ALGO = 'corr'
 
 @export
-@strax.takes_config(
-    amstrax.XAMSConfig(
-        name="channel_map",
-        default="rundoc://?path=xams_bookkeeping.channel_map&fallback=xams_default",
-        type=immutabledict,
-        track=False,
-        help="Map of channel groups loaded from rundoc xams_bookkeeping.channel_map",
-    ),
-    strax.Option('default_reconstruction_algorithm',
-                 default=DEFAULT_POSREC_ALGO,
-                 help="default reconstruction algorithm that provides (x,y)"
-    )
-)
 class PeakPositions(strax.Plugin):
     depends_on = ('peaks', 'peak_basics')
     rechunk_on_save = False
@@ -49,6 +36,18 @@ class PeakPositions(strax.Plugin):
         ('endtime', np.int64, 'End time of the peak (ns since unix epoch)')
     ]
 
+    channel_map = amstrax.XAMSConfig(
+        name="channel_map",
+        default="rundoc://?path=xams_bookkeeping.channel_map&fallback=xams_default",
+        type=immutabledict,
+        track=False,
+        help="Map of channel groups loaded from rundoc xams_bookkeeping.channel_map",
+    )
+    default_reconstruction_algorithm = strax.Option(
+        'default_reconstruction_algorithm',
+        default=DEFAULT_POSREC_ALGO,
+        help="default reconstruction algorithm that provides (x,y)"
+    )
     pos_rec_params = amstrax.XAMSConfig(
         default=[
             [212.89988642, -320.95097295, 198.71830514, -46.03953999],
@@ -56,10 +55,6 @@ class PeakPositions(strax.Plugin):
         ],
         help="Parameters for a correction function to go from x_cgr to true x and y_cgr to true y"
     )
-
-    def setup(self):
-        
-        self.default_reconstruction_algorithm = self.config['default_reconstruction_algorithm']
 
     def compute(self, peaks):
                 
@@ -70,7 +65,7 @@ class PeakPositions(strax.Plugin):
         top_sum = peaks['area']*peaks['area_fraction_top']
 
         # top is going to be (1,4)
-        top_map = self.config['channel_map']['top']
+        top_map = self.channel_map['top']
         top_indeces = np.arange(top_map[0], top_map[1]+1)
 
         # a bit convoluted, but necessary to avoid division by zero

--- a/amstrax/plugins/peaks/peak_positions.py
+++ b/amstrax/plugins/peaks/peak_positions.py
@@ -43,7 +43,7 @@ class PeakPositions(strax.Plugin):
         track=False,
         help="Map of channel groups loaded from rundoc xams_bookkeeping.channel_map",
     )
-    default_reconstruction_algorithm = strax.Config(
+    default_reconstruction_algorithm = amstrax.XAMSConfig(
         'default_reconstruction_algorithm',
         default=DEFAULT_POSREC_ALGO,
         help="default reconstruction algorithm that provides (x,y)"

--- a/amstrax/plugins/peaks/peak_positions.py
+++ b/amstrax/plugins/peaks/peak_positions.py
@@ -43,7 +43,7 @@ class PeakPositions(strax.Plugin):
         track=False,
         help="Map of channel groups loaded from rundoc xams_bookkeeping.channel_map",
     )
-    default_reconstruction_algorithm = strax.Option(
+    default_reconstruction_algorithm = strax.Config(
         'default_reconstruction_algorithm',
         default=DEFAULT_POSREC_ALGO,
         help="default reconstruction algorithm that provides (x,y)"

--- a/amstrax/plugins/peaks/peaks.py
+++ b/amstrax/plugins/peaks/peaks.py
@@ -8,7 +8,6 @@ export, __all__ = strax.exporter()
 # These are also needed in peaklets, since hitfinding is repeated
 HITFINDER_OPTIONS = tuple([
     amstrax.XAMSConfig(
-        'hit_min_amplitude',
         default='pmt_commissioning_initial',
         help='Minimum hit amplitude in ADC counts above baseline. '
              'See straxen.hit_min_amplitude for options.'
@@ -26,30 +25,30 @@ class Peaks(strax.Plugin):
     __version__ = '0.1.50'
 
     peak_gap_threshold = amstrax.XAMSConfig(
-        'peak_gap_threshold', default=300,
+        default=300,
         help="No hits for this many ns triggers a new peak")
     peak_left_extension = amstrax.XAMSConfig(
-        'peak_left_extension', default=10,
+        default=10,
         help="Include this many ns left of hits in peaks")
     peak_right_extension = amstrax.XAMSConfig(
-        'peak_right_extension', default=10,
+        default=10,
         help="Include this many ns right of hits in peaks")
     peak_min_area = amstrax.XAMSConfig(
-        'peak_min_area', default=10,
+        default=10,
         help="Minimum contributing PMTs needed to define a peak")
     peak_min_pmts = amstrax.XAMSConfig(
-        'peak_min_pmts', default=1,
+        default=1,
         help="Minimum contributing PMTs needed to define a peak")
     peak_split_min_height = amstrax.XAMSConfig(
-        'peak_split_min_height', default=25,
+        default=25,
         help="Minimum height in PE above a local sum waveform"
         "minimum, on either side, to trigger a split")
     peak_split_min_ratio = amstrax.XAMSConfig(
-        'peak_split_min_ratio', default=4,
+        default=4,
         help="Minimum ratio between local sum waveform"
         "minimum and maxima on either side, to trigger a split")
     n_tpc_pmts = amstrax.XAMSConfig(
-        'n_tpc_pmts', track=False, default=False,
+        track=False, default=False,
         help="Number of channels")
     gain_to_pe_array = amstrax.XAMSConfig(
         default=None,

--- a/amstrax/plugins/peaks/peaks.py
+++ b/amstrax/plugins/peaks/peaks.py
@@ -16,26 +16,6 @@ HITFINDER_OPTIONS = tuple([
 
 
 @export
-@strax.takes_config(
-    strax.Option('peak_gap_threshold', default=300,
-                 help="No hits for this many ns triggers a new peak"),
-    strax.Option('peak_left_extension', default=10,
-                 help="Include this many ns left of hits in peaks"),
-    strax.Option('peak_right_extension', default=10,
-                 help="Include this many ns right of hits in peaks"),
-    strax.Option('peak_min_area', default=10,
-                 help="Minimum contributing PMTs needed to define a peak"),
-    strax.Option('peak_min_pmts', default=1,
-                 help="Minimum contributing PMTs needed to define a peak"),
-    strax.Option('peak_split_min_height', default=25,
-                 help="Minimum height in PE above a local sum waveform"
-                      "minimum, on either side, to trigger a split"),
-    strax.Option('peak_split_min_ratio', default=4,
-                 help="Minimum ratio between local sum waveform"
-                      "minimum and maxima on either side, to trigger a split"),
-    strax.Option('n_tpc_pmts', track=False, default=False,
-                 help="Number of channels")
-)
 class Peaks(strax.Plugin):
     depends_on = ('records',)
     data_kind = 'peaks'
@@ -45,6 +25,32 @@ class Peaks(strax.Plugin):
 
     __version__ = '0.1.50'
 
+    peak_gap_threshold = strax.Option(
+        'peak_gap_threshold', default=300,
+        help="No hits for this many ns triggers a new peak")
+    peak_left_extension = strax.Option(
+        'peak_left_extension', default=10,
+        help="Include this many ns left of hits in peaks")
+    peak_right_extension = strax.Option(
+        'peak_right_extension', default=10,
+        help="Include this many ns right of hits in peaks")
+    peak_min_area = strax.Option(
+        'peak_min_area', default=10,
+        help="Minimum contributing PMTs needed to define a peak")
+    peak_min_pmts = strax.Option(
+        'peak_min_pmts', default=1,
+        help="Minimum contributing PMTs needed to define a peak")
+    peak_split_min_height = strax.Option(
+        'peak_split_min_height', default=25,
+        help="Minimum height in PE above a local sum waveform"
+        "minimum, on either side, to trigger a split")
+    peak_split_min_ratio = strax.Option(
+        'peak_split_min_ratio', default=4,
+        help="Minimum ratio between local sum waveform"
+        "minimum and maxima on either side, to trigger a split")
+    n_tpc_pmts = strax.Option(
+        'n_tpc_pmts', track=False, default=False,
+        help="Number of channels")
     gain_to_pe_array = amstrax.XAMSConfig(
         default=None,
         help="Gain to pe array"

--- a/amstrax/plugins/peaks/peaks.py
+++ b/amstrax/plugins/peaks/peaks.py
@@ -7,7 +7,7 @@ export, __all__ = strax.exporter()
 
 # These are also needed in peaklets, since hitfinding is repeated
 HITFINDER_OPTIONS = tuple([
-    strax.Config(
+    amstrax.XAMSConfig(
         'hit_min_amplitude',
         default='pmt_commissioning_initial',
         help='Minimum hit amplitude in ADC counts above baseline. '
@@ -25,30 +25,30 @@ class Peaks(strax.Plugin):
 
     __version__ = '0.1.50'
 
-    peak_gap_threshold = strax.Config(
+    peak_gap_threshold = amstrax.XAMSConfig(
         'peak_gap_threshold', default=300,
         help="No hits for this many ns triggers a new peak")
-    peak_left_extension = strax.Config(
+    peak_left_extension = amstrax.XAMSConfig(
         'peak_left_extension', default=10,
         help="Include this many ns left of hits in peaks")
-    peak_right_extension = strax.Config(
+    peak_right_extension = amstrax.XAMSConfig(
         'peak_right_extension', default=10,
         help="Include this many ns right of hits in peaks")
-    peak_min_area = strax.Config(
+    peak_min_area = amstrax.XAMSConfig(
         'peak_min_area', default=10,
         help="Minimum contributing PMTs needed to define a peak")
-    peak_min_pmts = strax.Config(
+    peak_min_pmts = amstrax.XAMSConfig(
         'peak_min_pmts', default=1,
         help="Minimum contributing PMTs needed to define a peak")
-    peak_split_min_height = strax.Config(
+    peak_split_min_height = amstrax.XAMSConfig(
         'peak_split_min_height', default=25,
         help="Minimum height in PE above a local sum waveform"
         "minimum, on either side, to trigger a split")
-    peak_split_min_ratio = strax.Config(
+    peak_split_min_ratio = amstrax.XAMSConfig(
         'peak_split_min_ratio', default=4,
         help="Minimum ratio between local sum waveform"
         "minimum and maxima on either side, to trigger a split")
-    n_tpc_pmts = strax.Config(
+    n_tpc_pmts = amstrax.XAMSConfig(
         'n_tpc_pmts', track=False, default=False,
         help="Number of channels")
     gain_to_pe_array = amstrax.XAMSConfig(

--- a/amstrax/plugins/peaks/peaks.py
+++ b/amstrax/plugins/peaks/peaks.py
@@ -7,7 +7,7 @@ export, __all__ = strax.exporter()
 
 # These are also needed in peaklets, since hitfinding is repeated
 HITFINDER_OPTIONS = tuple([
-    strax.Option(
+    strax.Config(
         'hit_min_amplitude',
         default='pmt_commissioning_initial',
         help='Minimum hit amplitude in ADC counts above baseline. '
@@ -25,30 +25,30 @@ class Peaks(strax.Plugin):
 
     __version__ = '0.1.50'
 
-    peak_gap_threshold = strax.Option(
+    peak_gap_threshold = strax.Config(
         'peak_gap_threshold', default=300,
         help="No hits for this many ns triggers a new peak")
-    peak_left_extension = strax.Option(
+    peak_left_extension = strax.Config(
         'peak_left_extension', default=10,
         help="Include this many ns left of hits in peaks")
-    peak_right_extension = strax.Option(
+    peak_right_extension = strax.Config(
         'peak_right_extension', default=10,
         help="Include this many ns right of hits in peaks")
-    peak_min_area = strax.Option(
+    peak_min_area = strax.Config(
         'peak_min_area', default=10,
         help="Minimum contributing PMTs needed to define a peak")
-    peak_min_pmts = strax.Option(
+    peak_min_pmts = strax.Config(
         'peak_min_pmts', default=1,
         help="Minimum contributing PMTs needed to define a peak")
-    peak_split_min_height = strax.Option(
+    peak_split_min_height = strax.Config(
         'peak_split_min_height', default=25,
         help="Minimum height in PE above a local sum waveform"
         "minimum, on either side, to trigger a split")
-    peak_split_min_ratio = strax.Option(
+    peak_split_min_ratio = strax.Config(
         'peak_split_min_ratio', default=4,
         help="Minimum ratio between local sum waveform"
         "minimum and maxima on either side, to trigger a split")
-    n_tpc_pmts = strax.Option(
+    n_tpc_pmts = strax.Config(
         'n_tpc_pmts', track=False, default=False,
         help="Number of channels")
     gain_to_pe_array = amstrax.XAMSConfig(

--- a/amstrax/plugins/peaks_ext/peak_basics_ext.py
+++ b/amstrax/plugins/peaks_ext/peak_basics_ext.py
@@ -16,9 +16,9 @@ class PeakBasicsEXT(strax.Plugin):
     parallel = "False"
     rechunk_on_save = False
     __version__ = "2.1"
-    s1_min_width = amstrax.XAMSConfig('s1_min_width', default=10, help="Minimum (IQR) width of S1s")
-    s1_max_width = amstrax.XAMSConfig('s1_max_width', default=225, help="Maximum (IQR) width of S1s")
-    s2_min_width = amstrax.XAMSConfig('s2_min_width', default=225, help="Minimum width for S2s")
+    s1_min_width = amstrax.XAMSConfig(default=10, help="Minimum (IQR) width of S1s")
+    s1_max_width = amstrax.XAMSConfig(default=225, help="Maximum (IQR) width of S1s")
+    s2_min_width = amstrax.XAMSConfig(default=225, help="Minimum width for S2s")
     dtype = [
         (('Start time of the peak (ns since unix epoch)',
           'time'), np.int64),

--- a/amstrax/plugins/peaks_ext/peak_basics_ext.py
+++ b/amstrax/plugins/peaks_ext/peak_basics_ext.py
@@ -8,23 +8,6 @@ export, __all__ = strax.exporter()
 
 # For n_competing, which is temporarily added to PeakBasics
 @export
-@strax.takes_config(
-    strax.Option(
-      's1_min_width', 
-      default=10,
-      help="Minimum (IQR) width of S1s"
-    ),
-    strax.Option(
-      's1_max_width',
-      default=225,
-      help="Maximum (IQR) width of S1s"
-    ),
-    strax.Option(
-      's2_min_width',
-      default=225,
-      help="Minimum width for S2s"
-    )
-)
 class PeakBasicsEXT(strax.Plugin):
     provides = ("peak_basics_ext",)
     depends_on = ("peaks_ext", )
@@ -33,6 +16,9 @@ class PeakBasicsEXT(strax.Plugin):
     parallel = "False"
     rechunk_on_save = False
     __version__ = "2.1"
+    s1_min_width = strax.Option('s1_min_width', default=10, help="Minimum (IQR) width of S1s")
+    s1_max_width = strax.Option('s1_max_width', default=225, help="Maximum (IQR) width of S1s")
+    s2_min_width = strax.Option('s2_min_width', default=225, help="Minimum width for S2s")
     dtype = [
         (('Start time of the peak (ns since unix epoch)',
           'time'), np.int64),

--- a/amstrax/plugins/peaks_ext/peak_basics_ext.py
+++ b/amstrax/plugins/peaks_ext/peak_basics_ext.py
@@ -16,9 +16,9 @@ class PeakBasicsEXT(strax.Plugin):
     parallel = "False"
     rechunk_on_save = False
     __version__ = "2.1"
-    s1_min_width = strax.Option('s1_min_width', default=10, help="Minimum (IQR) width of S1s")
-    s1_max_width = strax.Option('s1_max_width', default=225, help="Maximum (IQR) width of S1s")
-    s2_min_width = strax.Option('s2_min_width', default=225, help="Minimum width for S2s")
+    s1_min_width = strax.Config('s1_min_width', default=10, help="Minimum (IQR) width of S1s")
+    s1_max_width = strax.Config('s1_max_width', default=225, help="Maximum (IQR) width of S1s")
+    s2_min_width = strax.Config('s2_min_width', default=225, help="Minimum width for S2s")
     dtype = [
         (('Start time of the peak (ns since unix epoch)',
           'time'), np.int64),

--- a/amstrax/plugins/peaks_ext/peak_basics_ext.py
+++ b/amstrax/plugins/peaks_ext/peak_basics_ext.py
@@ -16,9 +16,9 @@ class PeakBasicsEXT(strax.Plugin):
     parallel = "False"
     rechunk_on_save = False
     __version__ = "2.1"
-    s1_min_width = strax.Config('s1_min_width', default=10, help="Minimum (IQR) width of S1s")
-    s1_max_width = strax.Config('s1_max_width', default=225, help="Maximum (IQR) width of S1s")
-    s2_min_width = strax.Config('s2_min_width', default=225, help="Minimum width for S2s")
+    s1_min_width = amstrax.XAMSConfig('s1_min_width', default=10, help="Minimum (IQR) width of S1s")
+    s1_max_width = amstrax.XAMSConfig('s1_max_width', default=225, help="Maximum (IQR) width of S1s")
+    s2_min_width = amstrax.XAMSConfig('s2_min_width', default=225, help="Minimum width for S2s")
     dtype = [
         (('Start time of the peak (ns since unix epoch)',
           'time'), np.int64),

--- a/amstrax/plugins/peaks_ext/peak_basics_ext.py
+++ b/amstrax/plugins/peaks_ext/peak_basics_ext.py
@@ -1,3 +1,4 @@
+import amstrax
 import numba
 import numpy as np
 import strax

--- a/amstrax/plugins/peaks_ext/peak_basics_sipm.py
+++ b/amstrax/plugins/peaks_ext/peak_basics_sipm.py
@@ -18,32 +18,30 @@ class PeakBasicsSiPM(strax.Plugin):
     rechunk_on_save = False
     __version__ = "2.1"
     channel_map = amstrax.XAMSConfig(
-        name="channel_map",
         default="rundoc://?path=xams_bookkeeping.channel_map&fallback=xams_default",
         type=immutabledict,
         track=False,
         help="Map of channel groups loaded from rundoc xams_bookkeeping.channel_map",
     )
     check_peak_sum_area_rtol = amstrax.XAMSConfig(
-        "check_peak_sum_area_rtol",
         default=1e-4,
         help="Check if the area of the sum-wf is the same as the total area"
         " (if the area of the peak is positively defined)."
         " Set to None to disable.",
     )
-    s1_min_width = amstrax.XAMSConfig('s1_min_width', default=10, help="Minimum (IQR) width of S1s")
-    s1_max_width = amstrax.XAMSConfig('s1_max_width', default=225, help="Maximum (IQR) width of S1s")
-    s1_min_area = amstrax.XAMSConfig('s1_min_area', default=10, help="Minimum area (PE) for S1s")
-    s2_min_area = amstrax.XAMSConfig('s2_min_area', default=10, help="Minimum area (PE) for S2s")
-    s2_min_width = amstrax.XAMSConfig('s2_min_width', default=225, help="Minimum width for S2s")
+    s1_min_width = amstrax.XAMSConfig(default=10, help="Minimum (IQR) width of S1s")
+    s1_max_width = amstrax.XAMSConfig(default=225, help="Maximum (IQR) width of S1s")
+    s1_min_area = amstrax.XAMSConfig(default=10, help="Minimum area (PE) for S1s")
+    s2_min_area = amstrax.XAMSConfig(default=10, help="Minimum area (PE) for S2s")
+    s2_min_width = amstrax.XAMSConfig(default=225, help="Minimum width for S2s")
     s1_min_channels = amstrax.XAMSConfig(
-        's1_min_channels', default=5, help="Minimum number of channels for S1s")
+        default=5, help="Minimum number of channels for S1s")
     s2_min_channels = amstrax.XAMSConfig(
-        's2_min_channels', default=5, help="Minimum number of channels for S2s")
+        default=5, help="Minimum number of channels for S2s")
     s2_min_area_fraction_top = amstrax.XAMSConfig(
-        's2_min_area_fraction_top', default=0, help="Minimum area fraction top for S2s")
+        default=0, help="Minimum area fraction top for S2s")
     s1_max_area_fraction_top = amstrax.XAMSConfig(
-        's1_max_area_fraction_top', default=.2, help="Maximum area fraction top for S1s")
+        default=.2, help="Maximum area fraction top for S1s")
     dtype = [
         (('Start time of the peak (ns since unix epoch)',
           'time'), np.int64),

--- a/amstrax/plugins/peaks_ext/peak_basics_sipm.py
+++ b/amstrax/plugins/peaks_ext/peak_basics_sipm.py
@@ -24,25 +24,25 @@ class PeakBasicsSiPM(strax.Plugin):
         track=False,
         help="Map of channel groups loaded from rundoc xams_bookkeeping.channel_map",
     )
-    check_peak_sum_area_rtol = strax.Config(
+    check_peak_sum_area_rtol = amstrax.XAMSConfig(
         "check_peak_sum_area_rtol",
         default=1e-4,
         help="Check if the area of the sum-wf is the same as the total area"
         " (if the area of the peak is positively defined)."
         " Set to None to disable.",
     )
-    s1_min_width = strax.Config('s1_min_width', default=10, help="Minimum (IQR) width of S1s")
-    s1_max_width = strax.Config('s1_max_width', default=225, help="Maximum (IQR) width of S1s")
-    s1_min_area = strax.Config('s1_min_area', default=10, help="Minimum area (PE) for S1s")
-    s2_min_area = strax.Config('s2_min_area', default=10, help="Minimum area (PE) for S2s")
-    s2_min_width = strax.Config('s2_min_width', default=225, help="Minimum width for S2s")
-    s1_min_channels = strax.Config(
+    s1_min_width = amstrax.XAMSConfig('s1_min_width', default=10, help="Minimum (IQR) width of S1s")
+    s1_max_width = amstrax.XAMSConfig('s1_max_width', default=225, help="Maximum (IQR) width of S1s")
+    s1_min_area = amstrax.XAMSConfig('s1_min_area', default=10, help="Minimum area (PE) for S1s")
+    s2_min_area = amstrax.XAMSConfig('s2_min_area', default=10, help="Minimum area (PE) for S2s")
+    s2_min_width = amstrax.XAMSConfig('s2_min_width', default=225, help="Minimum width for S2s")
+    s1_min_channels = amstrax.XAMSConfig(
         's1_min_channels', default=5, help="Minimum number of channels for S1s")
-    s2_min_channels = strax.Config(
+    s2_min_channels = amstrax.XAMSConfig(
         's2_min_channels', default=5, help="Minimum number of channels for S2s")
-    s2_min_area_fraction_top = strax.Config(
+    s2_min_area_fraction_top = amstrax.XAMSConfig(
         's2_min_area_fraction_top', default=0, help="Minimum area fraction top for S2s")
-    s1_max_area_fraction_top = strax.Config(
+    s1_max_area_fraction_top = amstrax.XAMSConfig(
         's1_max_area_fraction_top', default=.2, help="Maximum area fraction top for S1s")
     dtype = [
         (('Start time of the peak (ns since unix epoch)',

--- a/amstrax/plugins/peaks_ext/peak_basics_sipm.py
+++ b/amstrax/plugins/peaks_ext/peak_basics_sipm.py
@@ -24,25 +24,25 @@ class PeakBasicsSiPM(strax.Plugin):
         track=False,
         help="Map of channel groups loaded from rundoc xams_bookkeeping.channel_map",
     )
-    check_peak_sum_area_rtol = strax.Option(
+    check_peak_sum_area_rtol = strax.Config(
         "check_peak_sum_area_rtol",
         default=1e-4,
         help="Check if the area of the sum-wf is the same as the total area"
         " (if the area of the peak is positively defined)."
         " Set to None to disable.",
     )
-    s1_min_width = strax.Option('s1_min_width', default=10, help="Minimum (IQR) width of S1s")
-    s1_max_width = strax.Option('s1_max_width', default=225, help="Maximum (IQR) width of S1s")
-    s1_min_area = strax.Option('s1_min_area', default=10, help="Minimum area (PE) for S1s")
-    s2_min_area = strax.Option('s2_min_area', default=10, help="Minimum area (PE) for S2s")
-    s2_min_width = strax.Option('s2_min_width', default=225, help="Minimum width for S2s")
-    s1_min_channels = strax.Option(
+    s1_min_width = strax.Config('s1_min_width', default=10, help="Minimum (IQR) width of S1s")
+    s1_max_width = strax.Config('s1_max_width', default=225, help="Maximum (IQR) width of S1s")
+    s1_min_area = strax.Config('s1_min_area', default=10, help="Minimum area (PE) for S1s")
+    s2_min_area = strax.Config('s2_min_area', default=10, help="Minimum area (PE) for S2s")
+    s2_min_width = strax.Config('s2_min_width', default=225, help="Minimum width for S2s")
+    s1_min_channels = strax.Config(
         's1_min_channels', default=5, help="Minimum number of channels for S1s")
-    s2_min_channels = strax.Option(
+    s2_min_channels = strax.Config(
         's2_min_channels', default=5, help="Minimum number of channels for S2s")
-    s2_min_area_fraction_top = strax.Option(
+    s2_min_area_fraction_top = strax.Config(
         's2_min_area_fraction_top', default=0, help="Minimum area fraction top for S2s")
-    s1_max_area_fraction_top = strax.Option(
+    s1_max_area_fraction_top = strax.Config(
         's1_max_area_fraction_top', default=.2, help="Maximum area fraction top for S1s")
     dtype = [
         (('Start time of the peak (ns since unix epoch)',

--- a/amstrax/plugins/peaks_ext/peak_basics_sipm.py
+++ b/amstrax/plugins/peaks_ext/peak_basics_sipm.py
@@ -9,67 +9,6 @@ export, __all__ = strax.exporter()
 
 # For n_competing, which is temporarily added to PeakBasics
 @export
-@strax.takes_config(
-    amstrax.XAMSConfig(
-        name="channel_map",
-        default="rundoc://?path=xams_bookkeeping.channel_map&fallback=xams_default",
-        type=immutabledict,
-        track=False,
-        help="Map of channel groups loaded from rundoc xams_bookkeeping.channel_map",
-    ),
-    strax.Option(
-        "check_peak_sum_area_rtol",
-        default=1e-4,
-        help="Check if the area of the sum-wf is the same as the total area"
-        " (if the area of the peak is positively defined)."
-        " Set to None to disable.",
-    ),
-    strax.Option(
-      's1_min_width', 
-      default=10,
-      help="Minimum (IQR) width of S1s"
-    ),
-    strax.Option(
-      's1_max_width',
-      default=225,
-      help="Maximum (IQR) width of S1s"
-    ),
-    strax.Option(
-      's1_min_area',
-      default=10,
-      help="Minimum area (PE) for S1s"
-    ),
-    strax.Option(
-      's2_min_area',
-      default=10,
-      help="Minimum area (PE) for S2s"
-    ),
-    strax.Option(
-      's2_min_width',
-      default=225,
-      help="Minimum width for S2s"
-    ),
-    strax.Option(
-      's1_min_channels',
-      default=5,
-      help="Minimum number of channels for S1s"
-    ),
-    strax.Option(
-      's2_min_channels',
-      default=5,
-      help="Minimum number of channels for S2s"
-    ),
-    strax.Option(
-      's2_min_area_fraction_top',
-      default=0,
-      help="Minimum area fraction top for S2s"
-    ),
-    strax.Option(
-      's1_max_area_fraction_top',
-      default=.2,
-      help="Maximum area fraction top for S1s"
-    ),
-)
 class PeakBasicsSiPM(strax.Plugin):
     provides = ("peak_basics_sipm",)
     depends_on = ("peaks_sipm", )
@@ -78,6 +17,33 @@ class PeakBasicsSiPM(strax.Plugin):
     parallel = "False"
     rechunk_on_save = False
     __version__ = "2.1"
+    channel_map = amstrax.XAMSConfig(
+        name="channel_map",
+        default="rundoc://?path=xams_bookkeeping.channel_map&fallback=xams_default",
+        type=immutabledict,
+        track=False,
+        help="Map of channel groups loaded from rundoc xams_bookkeeping.channel_map",
+    )
+    check_peak_sum_area_rtol = strax.Option(
+        "check_peak_sum_area_rtol",
+        default=1e-4,
+        help="Check if the area of the sum-wf is the same as the total area"
+        " (if the area of the peak is positively defined)."
+        " Set to None to disable.",
+    )
+    s1_min_width = strax.Option('s1_min_width', default=10, help="Minimum (IQR) width of S1s")
+    s1_max_width = strax.Option('s1_max_width', default=225, help="Maximum (IQR) width of S1s")
+    s1_min_area = strax.Option('s1_min_area', default=10, help="Minimum area (PE) for S1s")
+    s2_min_area = strax.Option('s2_min_area', default=10, help="Minimum area (PE) for S2s")
+    s2_min_width = strax.Option('s2_min_width', default=225, help="Minimum width for S2s")
+    s1_min_channels = strax.Option(
+        's1_min_channels', default=5, help="Minimum number of channels for S1s")
+    s2_min_channels = strax.Option(
+        's2_min_channels', default=5, help="Minimum number of channels for S2s")
+    s2_min_area_fraction_top = strax.Option(
+        's2_min_area_fraction_top', default=0, help="Minimum area fraction top for S2s")
+    s1_max_area_fraction_top = strax.Option(
+        's1_max_area_fraction_top', default=.2, help="Maximum area fraction top for S1s")
     dtype = [
         (('Start time of the peak (ns since unix epoch)',
           'time'), np.int64),

--- a/amstrax/plugins/peaks_ext/peaks_ext.py
+++ b/amstrax/plugins/peaks_ext/peaks_ext.py
@@ -15,30 +15,30 @@ class PeaksEXT(strax.Plugin):
 
     __version__ = '0.0.3'
 
-    peak_gap_threshold = strax.Option(
+    peak_gap_threshold = strax.Config(
         'peak_gap_threshold', default=300,
         help="No hits for this many ns triggers a new peak")
-    peak_left_extension = strax.Option(
+    peak_left_extension = strax.Config(
         'peak_left_extension', default=10,
         help="Include this many ns left of hits in peaks")
-    peak_right_extension = strax.Option(
+    peak_right_extension = strax.Config(
         'peak_right_extension', default=10,
         help="Include this many ns right of hits in peaks")
-    peak_min_area = strax.Option(
+    peak_min_area = strax.Config(
         'peak_min_area', default=10,
         help="Minimum contributing PMTs needed to define a peak")
-    peak_split_min_height = strax.Option(
+    peak_split_min_height = strax.Config(
         'peak_split_min_height', default=25,
         help="Minimum height in PE above a local sum waveform"
         "minimum, on either side, to trigger a split")
-    peak_split_min_ratio = strax.Option(
+    peak_split_min_ratio = strax.Config(
         'peak_split_min_ratio', default=4,
         help="Minimum ratio between local sum waveform"
         "minimum and maxima on either side, to trigger a split")
-    n_tpc_pmts = strax.Option(
+    n_tpc_pmts = strax.Config(
         'n_tpc_pmts', track=False, default=False,
         help="Number of channels")
-    n_ext_pmts = strax.Option(
+    n_ext_pmts = strax.Config(
         'n_ext_pmts', track=True, default=1,
         help="Number of external channels")
     gain_to_pe_array = amstrax.XAMSConfig(

--- a/amstrax/plugins/peaks_ext/peaks_ext.py
+++ b/amstrax/plugins/peaks_ext/peaks_ext.py
@@ -6,26 +6,6 @@ import amstrax
 export, __all__ = strax.exporter()
 
 @export
-@strax.takes_config(
-    strax.Option('peak_gap_threshold', default=300,
-                 help="No hits for this many ns triggers a new peak"),
-    strax.Option('peak_left_extension', default=10,
-                 help="Include this many ns left of hits in peaks"),
-    strax.Option('peak_right_extension', default=10,
-                 help="Include this many ns right of hits in peaks"),
-    strax.Option('peak_min_area', default=10,
-                 help="Minimum contributing PMTs needed to define a peak"),
-    strax.Option('peak_split_min_height', default=25,
-                 help="Minimum height in PE above a local sum waveform"
-                      "minimum, on either side, to trigger a split"),
-    strax.Option('peak_split_min_ratio', default=4,
-                 help="Minimum ratio between local sum waveform"
-                      "minimum and maxima on either side, to trigger a split"),
-    strax.Option('n_tpc_pmts', track=False, default=False,
-                 help="Number of channels"), 
-    strax.Option('n_ext_pmts', track=True, default=1,
-                    help="Number of external channels"),
-)
 class PeaksEXT(strax.Plugin):
     depends_on = ('records_ext',)
     data_kind = 'peaks_ext'
@@ -35,6 +15,32 @@ class PeaksEXT(strax.Plugin):
 
     __version__ = '0.0.3'
 
+    peak_gap_threshold = strax.Option(
+        'peak_gap_threshold', default=300,
+        help="No hits for this many ns triggers a new peak")
+    peak_left_extension = strax.Option(
+        'peak_left_extension', default=10,
+        help="Include this many ns left of hits in peaks")
+    peak_right_extension = strax.Option(
+        'peak_right_extension', default=10,
+        help="Include this many ns right of hits in peaks")
+    peak_min_area = strax.Option(
+        'peak_min_area', default=10,
+        help="Minimum contributing PMTs needed to define a peak")
+    peak_split_min_height = strax.Option(
+        'peak_split_min_height', default=25,
+        help="Minimum height in PE above a local sum waveform"
+        "minimum, on either side, to trigger a split")
+    peak_split_min_ratio = strax.Option(
+        'peak_split_min_ratio', default=4,
+        help="Minimum ratio between local sum waveform"
+        "minimum and maxima on either side, to trigger a split")
+    n_tpc_pmts = strax.Option(
+        'n_tpc_pmts', track=False, default=False,
+        help="Number of channels")
+    n_ext_pmts = strax.Option(
+        'n_ext_pmts', track=True, default=1,
+        help="Number of external channels")
     gain_to_pe_array = amstrax.XAMSConfig(
         default=None,
         help="Gain to pe array"
@@ -50,7 +56,7 @@ class PeaksEXT(strax.Plugin):
 
         r = records_ext
   
-        if self.config['gain_to_pe_array'] is None:
+        if self.gain_to_pe_array is None:
             self.to_pe = np.ones(self.config['n_ext_pmts']+self.config['n_tpc_pmts'])
         else:
             self.to_pe = self.gain_to_pe_array

--- a/amstrax/plugins/peaks_ext/peaks_ext.py
+++ b/amstrax/plugins/peaks_ext/peaks_ext.py
@@ -15,30 +15,30 @@ class PeaksEXT(strax.Plugin):
 
     __version__ = '0.0.3'
 
-    peak_gap_threshold = strax.Config(
+    peak_gap_threshold = amstrax.XAMSConfig(
         'peak_gap_threshold', default=300,
         help="No hits for this many ns triggers a new peak")
-    peak_left_extension = strax.Config(
+    peak_left_extension = amstrax.XAMSConfig(
         'peak_left_extension', default=10,
         help="Include this many ns left of hits in peaks")
-    peak_right_extension = strax.Config(
+    peak_right_extension = amstrax.XAMSConfig(
         'peak_right_extension', default=10,
         help="Include this many ns right of hits in peaks")
-    peak_min_area = strax.Config(
+    peak_min_area = amstrax.XAMSConfig(
         'peak_min_area', default=10,
         help="Minimum contributing PMTs needed to define a peak")
-    peak_split_min_height = strax.Config(
+    peak_split_min_height = amstrax.XAMSConfig(
         'peak_split_min_height', default=25,
         help="Minimum height in PE above a local sum waveform"
         "minimum, on either side, to trigger a split")
-    peak_split_min_ratio = strax.Config(
+    peak_split_min_ratio = amstrax.XAMSConfig(
         'peak_split_min_ratio', default=4,
         help="Minimum ratio between local sum waveform"
         "minimum and maxima on either side, to trigger a split")
-    n_tpc_pmts = strax.Config(
+    n_tpc_pmts = amstrax.XAMSConfig(
         'n_tpc_pmts', track=False, default=False,
         help="Number of channels")
-    n_ext_pmts = strax.Config(
+    n_ext_pmts = amstrax.XAMSConfig(
         'n_ext_pmts', track=True, default=1,
         help="Number of external channels")
     gain_to_pe_array = amstrax.XAMSConfig(

--- a/amstrax/plugins/peaks_ext/peaks_ext.py
+++ b/amstrax/plugins/peaks_ext/peaks_ext.py
@@ -16,30 +16,30 @@ class PeaksEXT(strax.Plugin):
     __version__ = '0.0.3'
 
     peak_gap_threshold = amstrax.XAMSConfig(
-        'peak_gap_threshold', default=300,
+        default=300,
         help="No hits for this many ns triggers a new peak")
     peak_left_extension = amstrax.XAMSConfig(
-        'peak_left_extension', default=10,
+        default=10,
         help="Include this many ns left of hits in peaks")
     peak_right_extension = amstrax.XAMSConfig(
-        'peak_right_extension', default=10,
+        default=10,
         help="Include this many ns right of hits in peaks")
     peak_min_area = amstrax.XAMSConfig(
-        'peak_min_area', default=10,
+        default=10,
         help="Minimum contributing PMTs needed to define a peak")
     peak_split_min_height = amstrax.XAMSConfig(
-        'peak_split_min_height', default=25,
+        default=25,
         help="Minimum height in PE above a local sum waveform"
         "minimum, on either side, to trigger a split")
     peak_split_min_ratio = amstrax.XAMSConfig(
-        'peak_split_min_ratio', default=4,
+        default=4,
         help="Minimum ratio between local sum waveform"
         "minimum and maxima on either side, to trigger a split")
     n_tpc_pmts = amstrax.XAMSConfig(
-        'n_tpc_pmts', track=False, default=False,
+        track=False, default=False,
         help="Number of channels")
     n_ext_pmts = amstrax.XAMSConfig(
-        'n_ext_pmts', track=True, default=1,
+        track=True, default=1,
         help="Number of external channels")
     gain_to_pe_array = amstrax.XAMSConfig(
         default=None,

--- a/amstrax/plugins/peaks_ext/peaks_sipm.py
+++ b/amstrax/plugins/peaks_ext/peaks_sipm.py
@@ -15,33 +15,33 @@ class PeaksSiPM(strax.Plugin):
 
     __version__ = '0.0.2'
 
-    peak_gap_threshold = strax.Config(
+    peak_gap_threshold = amstrax.XAMSConfig(
         'peak_gap_threshold', default=300,
         help="No hits for this many ns triggers a new peak")
-    peak_left_extension = strax.Config(
+    peak_left_extension = amstrax.XAMSConfig(
         'peak_left_extension', default=10,
         help="Include this many ns left of hits in peaks")
-    peak_right_extension = strax.Config(
+    peak_right_extension = amstrax.XAMSConfig(
         'peak_right_extension', default=10,
         help="Include this many ns right of hits in peaks")
-    peak_min_area = strax.Config(
+    peak_min_area = amstrax.XAMSConfig(
         'peak_min_area', default=10,
         help="Minimum contributing PMTs needed to define a peak")
-    peak_split_min_height = strax.Config(
+    peak_split_min_height = amstrax.XAMSConfig(
         'peak_split_min_height', default=25,
         help="Minimum height in PE above a local sum waveform"
         "minimum, on either side, to trigger a split")
-    peak_split_min_ratio = strax.Config(
+    peak_split_min_ratio = amstrax.XAMSConfig(
         'peak_split_min_ratio', default=4,
         help="Minimum ratio between local sum waveform"
         "minimum and maxima on either side, to trigger a split")
-    n_tpc_pmts = strax.Config(
+    n_tpc_pmts = amstrax.XAMSConfig(
         'n_tpc_pmts', track=False, default=False,
         help="Number of channels")
-    n_ext_pmts = strax.Config(
+    n_ext_pmts = amstrax.XAMSConfig(
         'n_ext_pmts', track=True, default=1,
         help="Number of external channels")
-    n_sipms = strax.Config(
+    n_sipms = amstrax.XAMSConfig(
         'n_sipms', track=True, default=1,
         help="Number of external channels")
     gain_to_pe_array = amstrax.XAMSConfig(

--- a/amstrax/plugins/peaks_ext/peaks_sipm.py
+++ b/amstrax/plugins/peaks_ext/peaks_sipm.py
@@ -16,33 +16,33 @@ class PeaksSiPM(strax.Plugin):
     __version__ = '0.0.2'
 
     peak_gap_threshold = amstrax.XAMSConfig(
-        'peak_gap_threshold', default=300,
+        default=300,
         help="No hits for this many ns triggers a new peak")
     peak_left_extension = amstrax.XAMSConfig(
-        'peak_left_extension', default=10,
+        default=10,
         help="Include this many ns left of hits in peaks")
     peak_right_extension = amstrax.XAMSConfig(
-        'peak_right_extension', default=10,
+        default=10,
         help="Include this many ns right of hits in peaks")
     peak_min_area = amstrax.XAMSConfig(
-        'peak_min_area', default=10,
+        default=10,
         help="Minimum contributing PMTs needed to define a peak")
     peak_split_min_height = amstrax.XAMSConfig(
-        'peak_split_min_height', default=25,
+        default=25,
         help="Minimum height in PE above a local sum waveform"
         "minimum, on either side, to trigger a split")
     peak_split_min_ratio = amstrax.XAMSConfig(
-        'peak_split_min_ratio', default=4,
+        default=4,
         help="Minimum ratio between local sum waveform"
         "minimum and maxima on either side, to trigger a split")
     n_tpc_pmts = amstrax.XAMSConfig(
-        'n_tpc_pmts', track=False, default=False,
+        track=False, default=False,
         help="Number of channels")
     n_ext_pmts = amstrax.XAMSConfig(
-        'n_ext_pmts', track=True, default=1,
+        track=True, default=1,
         help="Number of external channels")
     n_sipms = amstrax.XAMSConfig(
-        'n_sipms', track=True, default=1,
+        track=True, default=1,
         help="Number of external channels")
     gain_to_pe_array = amstrax.XAMSConfig(
         default=None,

--- a/amstrax/plugins/peaks_ext/peaks_sipm.py
+++ b/amstrax/plugins/peaks_ext/peaks_sipm.py
@@ -15,33 +15,33 @@ class PeaksSiPM(strax.Plugin):
 
     __version__ = '0.0.2'
 
-    peak_gap_threshold = strax.Option(
+    peak_gap_threshold = strax.Config(
         'peak_gap_threshold', default=300,
         help="No hits for this many ns triggers a new peak")
-    peak_left_extension = strax.Option(
+    peak_left_extension = strax.Config(
         'peak_left_extension', default=10,
         help="Include this many ns left of hits in peaks")
-    peak_right_extension = strax.Option(
+    peak_right_extension = strax.Config(
         'peak_right_extension', default=10,
         help="Include this many ns right of hits in peaks")
-    peak_min_area = strax.Option(
+    peak_min_area = strax.Config(
         'peak_min_area', default=10,
         help="Minimum contributing PMTs needed to define a peak")
-    peak_split_min_height = strax.Option(
+    peak_split_min_height = strax.Config(
         'peak_split_min_height', default=25,
         help="Minimum height in PE above a local sum waveform"
         "minimum, on either side, to trigger a split")
-    peak_split_min_ratio = strax.Option(
+    peak_split_min_ratio = strax.Config(
         'peak_split_min_ratio', default=4,
         help="Minimum ratio between local sum waveform"
         "minimum and maxima on either side, to trigger a split")
-    n_tpc_pmts = strax.Option(
+    n_tpc_pmts = strax.Config(
         'n_tpc_pmts', track=False, default=False,
         help="Number of channels")
-    n_ext_pmts = strax.Option(
+    n_ext_pmts = strax.Config(
         'n_ext_pmts', track=True, default=1,
         help="Number of external channels")
-    n_sipms = strax.Option(
+    n_sipms = strax.Config(
         'n_sipms', track=True, default=1,
         help="Number of external channels")
     gain_to_pe_array = amstrax.XAMSConfig(

--- a/amstrax/plugins/peaks_ext/peaks_sipm.py
+++ b/amstrax/plugins/peaks_ext/peaks_sipm.py
@@ -6,28 +6,6 @@ import amstrax
 export, __all__ = strax.exporter()
 
 @export
-@strax.takes_config(
-    strax.Option('peak_gap_threshold', default=300,
-                 help="No hits for this many ns triggers a new peak"),
-    strax.Option('peak_left_extension', default=10,
-                 help="Include this many ns left of hits in peaks"),
-    strax.Option('peak_right_extension', default=10,
-                 help="Include this many ns right of hits in peaks"),
-    strax.Option('peak_min_area', default=10,
-                 help="Minimum contributing PMTs needed to define a peak"),
-    strax.Option('peak_split_min_height', default=25,
-                 help="Minimum height in PE above a local sum waveform"
-                      "minimum, on either side, to trigger a split"),
-    strax.Option('peak_split_min_ratio', default=4,
-                 help="Minimum ratio between local sum waveform"
-                      "minimum and maxima on either side, to trigger a split"),
-    strax.Option('n_tpc_pmts', track=False, default=False,
-                 help="Number of channels"), 
-    strax.Option('n_ext_pmts', track=True, default=1,
-                    help="Number of external channels"),
-    strax.Option('n_sipms', track=True, default=1,
-                    help="Number of external channels"),
-)
 class PeaksSiPM(strax.Plugin):
     depends_on = ('records_sipm',)
     data_kind = 'peaks_sipm'
@@ -37,6 +15,35 @@ class PeaksSiPM(strax.Plugin):
 
     __version__ = '0.0.2'
 
+    peak_gap_threshold = strax.Option(
+        'peak_gap_threshold', default=300,
+        help="No hits for this many ns triggers a new peak")
+    peak_left_extension = strax.Option(
+        'peak_left_extension', default=10,
+        help="Include this many ns left of hits in peaks")
+    peak_right_extension = strax.Option(
+        'peak_right_extension', default=10,
+        help="Include this many ns right of hits in peaks")
+    peak_min_area = strax.Option(
+        'peak_min_area', default=10,
+        help="Minimum contributing PMTs needed to define a peak")
+    peak_split_min_height = strax.Option(
+        'peak_split_min_height', default=25,
+        help="Minimum height in PE above a local sum waveform"
+        "minimum, on either side, to trigger a split")
+    peak_split_min_ratio = strax.Option(
+        'peak_split_min_ratio', default=4,
+        help="Minimum ratio between local sum waveform"
+        "minimum and maxima on either side, to trigger a split")
+    n_tpc_pmts = strax.Option(
+        'n_tpc_pmts', track=False, default=False,
+        help="Number of channels")
+    n_ext_pmts = strax.Option(
+        'n_ext_pmts', track=True, default=1,
+        help="Number of external channels")
+    n_sipms = strax.Option(
+        'n_sipms', track=True, default=1,
+        help="Number of external channels")
     gain_to_pe_array = amstrax.XAMSConfig(
         default=None,
         help="Gain to pe array"
@@ -52,7 +59,7 @@ class PeaksSiPM(strax.Plugin):
 
         r = records_sipm
   
-        if self.config['gain_to_pe_array'] is None:
+        if self.gain_to_pe_array is None:
             #FIXME -> numba doesn't like a NumPy array inside a NumPy array, so this will fail in strax.find_peaks()
             self.to_pe = np.ones(self.config['n_ext_pmts']+self.config['n_tpc_pmts']+self.config['n_sipms'], dtype=np.float32)
         else:

--- a/amstrax/plugins/raw_records/daqreader.py
+++ b/amstrax/plugins/raw_records/daqreader.py
@@ -23,77 +23,6 @@ class ArtificialDeadtimeInserted(UserWarning):
 
 
 @export
-@strax.takes_config(
-    # All these must have track=False, so the raw_records hash never changes!
-    # DAQ settings -- should match settings given to redax
-    strax.Option(
-        "record_length", default=110, track=False, type=int, help="Number of samples per raw_record"
-    ),
-    strax.Option(
-        "max_digitizer_sampling_time",
-        default=10,
-        track=False,
-        type=int,
-        help="Highest interval time of the digitizer sampling times(s) used.",
-    ),
-    strax.Option(
-        "run_start_time",
-        type=float,
-        track=False,
-        default=0,
-        help="time of start run (s since unix epoch)",
-    ),
-    strax.Option(
-        "daq_chunk_duration",
-        track=False,
-        default=int(5e9),
-        type=int,
-        help="Duration of regular chunks in ns",
-    ),
-    strax.Option(
-        "daq_overlap_chunk_duration",
-        track=False,
-        default=int(5e8),
-        type=int,
-        help="Duration of intermediate/overlap chunks in ns",
-    ),
-    strax.Option(
-        "daq_compressor",
-        default="lz4",
-        track=False,
-        help="Algorithm used for (de)compressing the live data",
-    ),
-    strax.Option(
-        "readout_threads",
-        type=dict,
-        track=False,
-        help=(
-            "Dictionary of the readout threads where the keys "
-            "specify the reader and value the number of threads"
-        ),
-    ),
-    strax.Option("daq_input_dir", type=str, track=False, help="Directory where readers put data"),
-    # DAQReader settings
-    strax.Option(
-        "safe_break_in_pulses",
-        default=1000,
-        track=False,
-        infer_type=False,
-        help=(
-            "Time (ns) between pulses indicating a safe break "
-            "in the datastream -- gaps of this size cannot be "
-            "interior to peaklets."
-        ),
-    ),
-    amstrax.XAMSConfig(
-        name="channel_map",
-        default="rundoc://?path=xams_bookkeeping.channel_map&fallback=xams_default",
-        track=False,
-        type=immutabledict,
-        infer_type=False,
-        help="immutabledict mapping subdetector to (min, max), loaded from rundoc",
-    ),
-)
 class DAQReader(strax.Plugin):
     """Read the XENONnT DAQ-live_data from redax and split it to the appropriate raw_record data-
     types based on the channel-map.
@@ -109,7 +38,7 @@ class DAQReader(strax.Plugin):
 
     provides: Tuple[str, ...] = (
         "raw_records_sipm",
-        "raw_records_ext",  
+        "raw_records_ext",
         "raw_records", # raw_records has to be last due to lineage
     )
 
@@ -126,6 +55,75 @@ class DAQReader(strax.Plugin):
     __version__ = "0.1.0"
     input_timeout = 300
 
+    # All these must have track=False, so the raw_records hash never changes.
+    # DAQ settings should match settings given to redax.
+    record_length = strax.Option(
+        "record_length", default=110, track=False, type=int, help="Number of samples per raw_record"
+    )
+    max_digitizer_sampling_time = strax.Option(
+        "max_digitizer_sampling_time",
+        default=10,
+        track=False,
+        type=int,
+        help="Highest interval time of the digitizer sampling times(s) used.",
+    )
+    run_start_time = strax.Option(
+        "run_start_time",
+        type=float,
+        track=False,
+        default=0,
+        help="time of start run (s since unix epoch)",
+    )
+    daq_chunk_duration = strax.Option(
+        "daq_chunk_duration",
+        track=False,
+        default=int(5e9),
+        type=int,
+        help="Duration of regular chunks in ns",
+    )
+    daq_overlap_chunk_duration = strax.Option(
+        "daq_overlap_chunk_duration",
+        track=False,
+        default=int(5e8),
+        type=int,
+        help="Duration of intermediate/overlap chunks in ns",
+    )
+    daq_compressor = strax.Option(
+        "daq_compressor",
+        default="lz4",
+        track=False,
+        help="Algorithm used for (de)compressing the live data",
+    )
+    readout_threads = strax.Option(
+        "readout_threads",
+        type=dict,
+        track=False,
+        help=(
+            "Dictionary of the readout threads where the keys "
+            "specify the reader and value the number of threads"
+        ),
+    )
+    daq_input_dir = strax.Option(
+        "daq_input_dir", type=str, track=False, help="Directory where readers put data")
+    safe_break_in_pulses = strax.Option(
+        "safe_break_in_pulses",
+        default=1000,
+        track=False,
+        infer_type=False,
+        help=(
+            "Time (ns) between pulses indicating a safe break "
+            "in the datastream -- gaps of this size cannot be "
+            "interior to peaklets."
+        ),
+    )
+    channel_map = amstrax.XAMSConfig(
+        name="channel_map",
+        default="rundoc://?path=xams_bookkeeping.channel_map&fallback=xams_default",
+        track=False,
+        type=immutabledict,
+        infer_type=False,
+        help="immutabledict mapping subdetector to (min, max), loaded from rundoc",
+    )
 
 
     def infer_dtype(self):
@@ -230,7 +228,7 @@ class DAQReader(strax.Plugin):
             # Records are sorted by (start)time and are of variable length.
             # Their end-times can differ. In the most pessimistic case we have
             # to look back one record length for each channel.
-            tot_channels = np.sum([np.diff(x) + 1 for x in self.config["channel_map"].values()])
+            tot_channels = np.sum([np.diff(x) + 1 for x in self.channel_map.values()])
             look_n_samples = self.config["record_length"] * tot_channels
             last_end = strax.endtime(records[-look_n_samples:]).max()
             if first_start < start or last_start >= end:
@@ -351,20 +349,20 @@ class DAQReader(strax.Plugin):
 
 
         # Split records by channel
-        tpc_min = min(self.config['channel_map']['bottom'][0], self.config['channel_map']['top'][0])
-        tpc_max = max(self.config['channel_map']['bottom'][1], self.config['channel_map']['top'][1])
+        tpc_min = min(self.channel_map['bottom'][0], self.channel_map['top'][0])
+        tpc_max = max(self.channel_map['bottom'][1], self.channel_map['top'][1])
 
         channel_ranges = {
             'tpc': (tpc_min, tpc_max),
         }
 
-        if 'external' in self.config['channel_map']:
-            channel_ranges['external'] = self.config['channel_map']['external']
+        if 'external' in self.channel_map:
+            channel_ranges['external'] = self.channel_map['external']
         else:
             channel_ranges['external'] = (-1, -1)
 
-        if 'sipm' in self.config['channel_map']:
-            channel_ranges['sipm'] = self.config['channel_map']['sipm']
+        if 'sipm' in self.channel_map:
+            channel_ranges['sipm'] = self.channel_map['sipm']
         else:
             channel_ranges['sipm'] = (-2, -2)
 

--- a/amstrax/plugins/raw_records/daqreader.py
+++ b/amstrax/plugins/raw_records/daqreader.py
@@ -57,44 +57,44 @@ class DAQReader(strax.Plugin):
 
     # All these must have track=False, so the raw_records hash never changes.
     # DAQ settings should match settings given to redax.
-    record_length = strax.Config(
+    record_length = amstrax.XAMSConfig(
         "record_length", default=110, track=False, type=int, help="Number of samples per raw_record"
     )
-    max_digitizer_sampling_time = strax.Config(
+    max_digitizer_sampling_time = amstrax.XAMSConfig(
         "max_digitizer_sampling_time",
         default=10,
         track=False,
         type=int,
         help="Highest interval time of the digitizer sampling times(s) used.",
     )
-    run_start_time = strax.Config(
+    run_start_time = amstrax.XAMSConfig(
         "run_start_time",
         type=float,
         track=False,
         default=0,
         help="time of start run (s since unix epoch)",
     )
-    daq_chunk_duration = strax.Config(
+    daq_chunk_duration = amstrax.XAMSConfig(
         "daq_chunk_duration",
         track=False,
         default=int(5e9),
         type=int,
         help="Duration of regular chunks in ns",
     )
-    daq_overlap_chunk_duration = strax.Config(
+    daq_overlap_chunk_duration = amstrax.XAMSConfig(
         "daq_overlap_chunk_duration",
         track=False,
         default=int(5e8),
         type=int,
         help="Duration of intermediate/overlap chunks in ns",
     )
-    daq_compressor = strax.Config(
+    daq_compressor = amstrax.XAMSConfig(
         "daq_compressor",
         default="lz4",
         track=False,
         help="Algorithm used for (de)compressing the live data",
     )
-    readout_threads = strax.Config(
+    readout_threads = amstrax.XAMSConfig(
         "readout_threads",
         type=dict,
         track=False,
@@ -103,9 +103,9 @@ class DAQReader(strax.Plugin):
             "specify the reader and value the number of threads"
         ),
     )
-    daq_input_dir = strax.Config(
+    daq_input_dir = amstrax.XAMSConfig(
         "daq_input_dir", type=str, track=False, help="Directory where readers put data")
-    safe_break_in_pulses = strax.Config(
+    safe_break_in_pulses = amstrax.XAMSConfig(
         "safe_break_in_pulses",
         default=1000,
         track=False,

--- a/amstrax/plugins/raw_records/daqreader.py
+++ b/amstrax/plugins/raw_records/daqreader.py
@@ -58,44 +58,38 @@ class DAQReader(strax.Plugin):
     # All these must have track=False, so the raw_records hash never changes.
     # DAQ settings should match settings given to redax.
     record_length = amstrax.XAMSConfig(
-        "record_length", default=110, track=False, type=int, help="Number of samples per raw_record"
+        default=110, track=False, type=int, help="Number of samples per raw_record"
     )
     max_digitizer_sampling_time = amstrax.XAMSConfig(
-        "max_digitizer_sampling_time",
         default=10,
         track=False,
         type=int,
         help="Highest interval time of the digitizer sampling times(s) used.",
     )
     run_start_time = amstrax.XAMSConfig(
-        "run_start_time",
         type=float,
         track=False,
         default=0,
         help="time of start run (s since unix epoch)",
     )
     daq_chunk_duration = amstrax.XAMSConfig(
-        "daq_chunk_duration",
         track=False,
         default=int(5e9),
         type=int,
         help="Duration of regular chunks in ns",
     )
     daq_overlap_chunk_duration = amstrax.XAMSConfig(
-        "daq_overlap_chunk_duration",
         track=False,
         default=int(5e8),
         type=int,
         help="Duration of intermediate/overlap chunks in ns",
     )
     daq_compressor = amstrax.XAMSConfig(
-        "daq_compressor",
         default="lz4",
         track=False,
         help="Algorithm used for (de)compressing the live data",
     )
     readout_threads = amstrax.XAMSConfig(
-        "readout_threads",
         type=dict,
         track=False,
         help=(
@@ -104,9 +98,8 @@ class DAQReader(strax.Plugin):
         ),
     )
     daq_input_dir = amstrax.XAMSConfig(
-        "daq_input_dir", type=str, track=False, help="Directory where readers put data")
+        type=str, track=False, help="Directory where readers put data")
     safe_break_in_pulses = amstrax.XAMSConfig(
-        "safe_break_in_pulses",
         default=1000,
         track=False,
         infer_type=False,
@@ -117,7 +110,6 @@ class DAQReader(strax.Plugin):
         ),
     )
     channel_map = amstrax.XAMSConfig(
-        name="channel_map",
         default="rundoc://?path=xams_bookkeeping.channel_map&fallback=xams_default",
         track=False,
         type=immutabledict,

--- a/amstrax/plugins/raw_records/daqreader.py
+++ b/amstrax/plugins/raw_records/daqreader.py
@@ -57,44 +57,44 @@ class DAQReader(strax.Plugin):
 
     # All these must have track=False, so the raw_records hash never changes.
     # DAQ settings should match settings given to redax.
-    record_length = strax.Option(
+    record_length = strax.Config(
         "record_length", default=110, track=False, type=int, help="Number of samples per raw_record"
     )
-    max_digitizer_sampling_time = strax.Option(
+    max_digitizer_sampling_time = strax.Config(
         "max_digitizer_sampling_time",
         default=10,
         track=False,
         type=int,
         help="Highest interval time of the digitizer sampling times(s) used.",
     )
-    run_start_time = strax.Option(
+    run_start_time = strax.Config(
         "run_start_time",
         type=float,
         track=False,
         default=0,
         help="time of start run (s since unix epoch)",
     )
-    daq_chunk_duration = strax.Option(
+    daq_chunk_duration = strax.Config(
         "daq_chunk_duration",
         track=False,
         default=int(5e9),
         type=int,
         help="Duration of regular chunks in ns",
     )
-    daq_overlap_chunk_duration = strax.Option(
+    daq_overlap_chunk_duration = strax.Config(
         "daq_overlap_chunk_duration",
         track=False,
         default=int(5e8),
         type=int,
         help="Duration of intermediate/overlap chunks in ns",
     )
-    daq_compressor = strax.Option(
+    daq_compressor = strax.Config(
         "daq_compressor",
         default="lz4",
         track=False,
         help="Algorithm used for (de)compressing the live data",
     )
-    readout_threads = strax.Option(
+    readout_threads = strax.Config(
         "readout_threads",
         type=dict,
         track=False,
@@ -103,9 +103,9 @@ class DAQReader(strax.Plugin):
             "specify the reader and value the number of threads"
         ),
     )
-    daq_input_dir = strax.Option(
+    daq_input_dir = strax.Config(
         "daq_input_dir", type=str, track=False, help="Directory where readers put data")
-    safe_break_in_pulses = strax.Option(
+    safe_break_in_pulses = strax.Config(
         "safe_break_in_pulses",
         default=1000,
         track=False,

--- a/amstrax/plugins/records/pulse_processing.py
+++ b/amstrax/plugins/records/pulse_processing.py
@@ -9,7 +9,7 @@ export, __all__ = strax.exporter()
 __all__ += ['NO_PULSE_COUNTS']
 
 HITFINDER_OPTIONS = tuple([
-    strax.Config(
+    amstrax.XAMSConfig(
         'hit_min_amplitude',
         default='xams_thresholds',
         help='Minimum hit amplitude in ADC counts above baseline. '
@@ -38,29 +38,29 @@ class PulseProcessing(strax.Plugin):
     baseline rms channel.
     """
     __version__ = '0.3.0'
-    baseline_samples = strax.Config(
+    baseline_samples = amstrax.XAMSConfig(
         'baseline_samples',
         default=20,
         infer_type=False,
         help='Number of samples to use at the start of the pulse to determine the baseline')
-    pmt_pulse_filter = strax.Config(
+    pmt_pulse_filter = amstrax.XAMSConfig(
         'pmt_pulse_filter',
         default=None,
         infer_type=False,
         help='Linear filter to apply to pulses, will be normalized.')
-    save_outside_hits = strax.Config(
+    save_outside_hits = amstrax.XAMSConfig(
         'save_outside_hits',
         default=(3, 20),
         infer_type=False,
         help='Save (left, right) samples besides hits; cut the rest')
-    n_tpc_pmts = strax.Config('n_tpc_pmts', type=int, help='Number of TPC channels')
-    check_raw_record_overlaps = strax.Config(
+    n_tpc_pmts = amstrax.XAMSConfig('n_tpc_pmts', type=int, help='Number of TPC channels')
+    check_raw_record_overlaps = amstrax.XAMSConfig(
         'check_raw_record_overlaps',
         default=True,
         track=False,
         infer_type=False,
         help='Crash if any of the pulses in raw_records overlap with others in the same channel')
-    allow_sloppy_chunking = strax.Config(
+    allow_sloppy_chunking = amstrax.XAMSConfig(
         'allow_sloppy_chunking',
         default=True,
         track=False,

--- a/amstrax/plugins/records/pulse_processing.py
+++ b/amstrax/plugins/records/pulse_processing.py
@@ -9,7 +9,7 @@ export, __all__ = strax.exporter()
 __all__ += ['NO_PULSE_COUNTS']
 
 HITFINDER_OPTIONS = tuple([
-    strax.Option(
+    strax.Config(
         'hit_min_amplitude',
         default='xams_thresholds',
         help='Minimum hit amplitude in ADC counts above baseline. '
@@ -38,29 +38,29 @@ class PulseProcessing(strax.Plugin):
     baseline rms channel.
     """
     __version__ = '0.3.0'
-    baseline_samples = strax.Option(
+    baseline_samples = strax.Config(
         'baseline_samples',
         default=20,
         infer_type=False,
         help='Number of samples to use at the start of the pulse to determine the baseline')
-    pmt_pulse_filter = strax.Option(
+    pmt_pulse_filter = strax.Config(
         'pmt_pulse_filter',
         default=None,
         infer_type=False,
         help='Linear filter to apply to pulses, will be normalized.')
-    save_outside_hits = strax.Option(
+    save_outside_hits = strax.Config(
         'save_outside_hits',
         default=(3, 20),
         infer_type=False,
         help='Save (left, right) samples besides hits; cut the rest')
-    n_tpc_pmts = strax.Option('n_tpc_pmts', type=int, help='Number of TPC channels')
-    check_raw_record_overlaps = strax.Option(
+    n_tpc_pmts = strax.Config('n_tpc_pmts', type=int, help='Number of TPC channels')
+    check_raw_record_overlaps = strax.Config(
         'check_raw_record_overlaps',
         default=True,
         track=False,
         infer_type=False,
         help='Crash if any of the pulses in raw_records overlap with others in the same channel')
-    allow_sloppy_chunking = strax.Option(
+    allow_sloppy_chunking = strax.Config(
         'allow_sloppy_chunking',
         default=True,
         track=False,

--- a/amstrax/plugins/records/pulse_processing.py
+++ b/amstrax/plugins/records/pulse_processing.py
@@ -10,7 +10,6 @@ __all__ += ['NO_PULSE_COUNTS']
 
 HITFINDER_OPTIONS = tuple([
     amstrax.XAMSConfig(
-        'hit_min_amplitude',
         default='xams_thresholds',
         help='Minimum hit amplitude in ADC counts above baseline. '
              'See amstrax.hit_min_amplitude in hitfinder_thresholds.py for options.'
@@ -39,29 +38,24 @@ class PulseProcessing(strax.Plugin):
     """
     __version__ = '0.3.0'
     baseline_samples = amstrax.XAMSConfig(
-        'baseline_samples',
         default=20,
         infer_type=False,
         help='Number of samples to use at the start of the pulse to determine the baseline')
     pmt_pulse_filter = amstrax.XAMSConfig(
-        'pmt_pulse_filter',
         default=None,
         infer_type=False,
         help='Linear filter to apply to pulses, will be normalized.')
     save_outside_hits = amstrax.XAMSConfig(
-        'save_outside_hits',
         default=(3, 20),
         infer_type=False,
         help='Save (left, right) samples besides hits; cut the rest')
-    n_tpc_pmts = amstrax.XAMSConfig('n_tpc_pmts', type=int, help='Number of TPC channels')
+    n_tpc_pmts = amstrax.XAMSConfig(type=int, help='Number of TPC channels')
     check_raw_record_overlaps = amstrax.XAMSConfig(
-        'check_raw_record_overlaps',
         default=True,
         track=False,
         infer_type=False,
         help='Crash if any of the pulses in raw_records overlap with others in the same channel')
     allow_sloppy_chunking = amstrax.XAMSConfig(
-        'allow_sloppy_chunking',
         default=True,
         track=False,
         infer_type=False,

--- a/amstrax/plugins/records/pulse_processing.py
+++ b/amstrax/plugins/records/pulse_processing.py
@@ -18,35 +18,6 @@ HITFINDER_OPTIONS = tuple([
 
 
 @export
-@strax.takes_config(
-    strax.Option(
-        'baseline_samples',
-        default=20, infer_type=False,
-        help='Number of samples to use at the start of the pulse to determine '
-             'the baseline'),
-    # PMT pulse processing options
-    strax.Option(
-        'pmt_pulse_filter',
-        default=None, infer_type=False,
-        help='Linear filter to apply to pulses, will be normalized.'),   
-    strax.Option(
-        'save_outside_hits',
-        default=(3, 20), infer_type=False,
-        help='Save (left, right) samples besides hits; cut the rest'),
-    strax.Option(
-        'n_tpc_pmts', type=int,
-        help='Number of TPC channels'),
-    strax.Option(
-        'check_raw_record_overlaps',
-        default=True, track=False, infer_type=False,
-        help='Crash if any of the pulses in raw_records overlap with others '
-             'in the same channel'),
-    strax.Option(
-        'allow_sloppy_chunking',
-        default=True, track=False, infer_type=False,
-        help=('Use a default baseline for incorrectly chunked fragments. '
-              'This is a kludge for improperly converted XENON1T data.')),
-    *HITFINDER_OPTIONS)
 class PulseProcessing(strax.Plugin):
     """
     Get the specific raw_records of the measurements 
@@ -67,6 +38,36 @@ class PulseProcessing(strax.Plugin):
     baseline rms channel.
     """
     __version__ = '0.3.0'
+    baseline_samples = strax.Option(
+        'baseline_samples',
+        default=20,
+        infer_type=False,
+        help='Number of samples to use at the start of the pulse to determine the baseline')
+    pmt_pulse_filter = strax.Option(
+        'pmt_pulse_filter',
+        default=None,
+        infer_type=False,
+        help='Linear filter to apply to pulses, will be normalized.')
+    save_outside_hits = strax.Option(
+        'save_outside_hits',
+        default=(3, 20),
+        infer_type=False,
+        help='Save (left, right) samples besides hits; cut the rest')
+    n_tpc_pmts = strax.Option('n_tpc_pmts', type=int, help='Number of TPC channels')
+    check_raw_record_overlaps = strax.Option(
+        'check_raw_record_overlaps',
+        default=True,
+        track=False,
+        infer_type=False,
+        help='Crash if any of the pulses in raw_records overlap with others in the same channel')
+    allow_sloppy_chunking = strax.Option(
+        'allow_sloppy_chunking',
+        default=True,
+        track=False,
+        infer_type=False,
+        help=('Use a default baseline for incorrectly chunked fragments. '
+              'This is a kludge for improperly converted XENON1T data.'))
+    hit_min_amplitude = HITFINDER_OPTIONS[0]
     
     parallel = 'process'
     rechunk_on_save = immutabledict(

--- a/amstrax/plugins/records_ext/pulse_processing_ext.py
+++ b/amstrax/plugins/records_ext/pulse_processing_ext.py
@@ -16,7 +16,7 @@ class PulseProcessingEXT(strax.Plugin):
     5. Pulse length and area calculation
 
     """
-    baseline_samples = strax.Option(
+    baseline_samples = strax.Config(
         'baseline_samples',
         default=20, infer_type=False,
         help='Number of samples to use at the start of the pulse to determine '

--- a/amstrax/plugins/records_ext/pulse_processing_ext.py
+++ b/amstrax/plugins/records_ext/pulse_processing_ext.py
@@ -17,7 +17,6 @@ class PulseProcessingEXT(strax.Plugin):
 
     """
     baseline_samples = amstrax.XAMSConfig(
-        'baseline_samples',
         default=20, infer_type=False,
         help='Number of samples to use at the start of the pulse to determine '
              'the baseline')

--- a/amstrax/plugins/records_ext/pulse_processing_ext.py
+++ b/amstrax/plugins/records_ext/pulse_processing_ext.py
@@ -16,7 +16,7 @@ class PulseProcessingEXT(strax.Plugin):
     5. Pulse length and area calculation
 
     """
-    baseline_samples = strax.Config(
+    baseline_samples = amstrax.XAMSConfig(
         'baseline_samples',
         default=20, infer_type=False,
         help='Number of samples to use at the start of the pulse to determine '

--- a/amstrax/plugins/records_ext/pulse_processing_ext.py
+++ b/amstrax/plugins/records_ext/pulse_processing_ext.py
@@ -1,3 +1,4 @@
+import amstrax
 import numba
 import numpy as np
 import strax

--- a/amstrax/plugins/records_ext/pulse_processing_ext.py
+++ b/amstrax/plugins/records_ext/pulse_processing_ext.py
@@ -6,13 +6,6 @@ from immutabledict import immutabledict
 export, __all__ = strax.exporter()
 
 @export
-@strax.takes_config(
-    strax.Option(
-        'baseline_samples',
-        default=20, infer_type=False,
-        help='Number of samples to use at the start of the pulse to determine '
-             'the baseline'),
-)
 class PulseProcessingEXT(strax.Plugin):
     """
     Plugin which performs the pulse processing steps:
@@ -23,6 +16,12 @@ class PulseProcessingEXT(strax.Plugin):
     5. Pulse length and area calculation
 
     """
+    baseline_samples = strax.Option(
+        'baseline_samples',
+        default=20, infer_type=False,
+        help='Number of samples to use at the start of the pulse to determine '
+             'the baseline')
+
     __version__ = '0.0.1'
     
     parallel = 'process'

--- a/amstrax/plugins/records_ext/pulse_processing_sipm.py
+++ b/amstrax/plugins/records_ext/pulse_processing_sipm.py
@@ -17,7 +17,6 @@ class PulseProcessingSiPM(strax.Plugin):
 
     """
     baseline_samples = amstrax.XAMSConfig(
-        'baseline_samples',
         default=20, infer_type=False,
         help='Number of samples to use at the start of the SiPM pulse to determine '
              'the baseline')

--- a/amstrax/plugins/records_ext/pulse_processing_sipm.py
+++ b/amstrax/plugins/records_ext/pulse_processing_sipm.py
@@ -16,7 +16,7 @@ class PulseProcessingSiPM(strax.Plugin):
     5. Pulse length and area calculation
 
     """
-    baseline_samples = strax.Config(
+    baseline_samples = amstrax.XAMSConfig(
         'baseline_samples',
         default=20, infer_type=False,
         help='Number of samples to use at the start of the SiPM pulse to determine '

--- a/amstrax/plugins/records_ext/pulse_processing_sipm.py
+++ b/amstrax/plugins/records_ext/pulse_processing_sipm.py
@@ -6,13 +6,6 @@ from immutabledict import immutabledict
 export, __all__ = strax.exporter()
 
 @export
-@strax.takes_config(
-    strax.Option(
-        'baseline_samples',
-        default=20, infer_type=False,
-        help='Number of samples to use at the start of the SiPM pulse to determine '
-             'the baseline'),
-)
 class PulseProcessingSiPM(strax.Plugin):
     """
     Plugin which performs the pulse processing steps:
@@ -23,6 +16,12 @@ class PulseProcessingSiPM(strax.Plugin):
     5. Pulse length and area calculation
 
     """
+    baseline_samples = strax.Option(
+        'baseline_samples',
+        default=20, infer_type=False,
+        help='Number of samples to use at the start of the SiPM pulse to determine '
+             'the baseline')
+
     __version__ = '0.0.2'
     
     parallel = 'process'

--- a/amstrax/plugins/records_ext/pulse_processing_sipm.py
+++ b/amstrax/plugins/records_ext/pulse_processing_sipm.py
@@ -16,7 +16,7 @@ class PulseProcessingSiPM(strax.Plugin):
     5. Pulse length and area calculation
 
     """
-    baseline_samples = strax.Option(
+    baseline_samples = strax.Config(
         'baseline_samples',
         default=20, infer_type=False,
         help='Number of samples to use at the start of the SiPM pulse to determine '

--- a/amstrax/plugins/records_ext/pulse_processing_sipm.py
+++ b/amstrax/plugins/records_ext/pulse_processing_sipm.py
@@ -1,3 +1,4 @@
+import amstrax
 import numba
 import numpy as np
 import strax

--- a/tests/test_corrections.py
+++ b/tests/test_corrections.py
@@ -47,7 +47,6 @@ class TestXAMSConfigCaching(unittest.TestCase):
         Rundoc-backed config values must not be reused across run IDs.
         """
         cfg = amstrax.XAMSConfig(
-            name="channel_map",
             default="rundoc://?path=daq_config.channel_map",
         )
         calls = []


### PR DESCRIPTION
## Summary

Move amstrax plugin configuration declarations to the descriptor-style `strax.Option` / `amstrax.XAMSConfig` paradigm.

This is split out from #326 so the polarity/raw-record behavior stays reviewable separately from config-style cleanup.

## Changes

- Remove `@strax.takes_config` usage from plugins.
- Define plugin config as class-level descriptors.
- Convert mixed XAMSConfig plugins first, then pure strax-option plugins.
- Keep existing option names/defaults/help text behavior as close as possible.

## Validation

- Confirmed no `@strax.takes_config` remains under `amstrax/plugins`.
- No-write Python syntax checks via `ast.parse` for all plugin files.
- `git diff --check` passed.

Full unittest execution is still blocked in this local checkout by missing local dependency `sshtunnel` and disk pressure.
