### PR TITLE
Route run handling through rundoc metadata

### DIFF
--- a/amstrax/__init__.py
+++ b/amstrax/__init__.py
@@ -4,6 +4,8 @@ from .common import *
 from .rundb import *
 from .logging_utils import *
 
+from .run_metadata import *
+
 from . import xams_config
 from .xams_config import *
 

--- a/amstrax/analyses/plotting.py
+++ b/amstrax/analyses/plotting.py
@@ -323,7 +323,7 @@ def plot_led_records(context, run_id, records_led, n_records=100, **kwargs):
         **kwargs: Unknown.
 
     Raises:
-        ValueError: If the run ID is not found in the database or if the run is not an external trigger run.
+        ValueError: If the run ID is not found in the database or if the run is not an LED run.
 
     Returns:
         None
@@ -332,14 +332,14 @@ def plot_led_records(context, run_id, records_led, n_records=100, **kwargs):
 
     rd = db.find_one({"number": int(run_id)})
 
-    print(rd["mode"])
-
     if not rd:
         raise ValueError(f"Run {run_id} not found in the database.")
 
-    if "ext_trig" not in rd["mode"]:
+    print(amstrax.get_run_mode(rd))
+
+    if not amstrax.is_led_run(rd):
         raise ValueError(
-            "This run doesn't look like an external trigger run, so better to avoid this plot."
+            "This run doesn't look like an LED run, so better to avoid this plot."
         )
 
     st = context
@@ -442,14 +442,14 @@ def plot_led_areas(context, run_id, led_calibration, **kwargs):
 
     rd = db.find_one({"number": int(run_id)})
 
-    print(rd["mode"])
-
     if not rd:
         raise ValueError(f"Run {run_id} not found in the database.")
 
-    if "ext_trig" not in rd["mode"]:
+    print(amstrax.get_run_mode(rd))
+
+    if not amstrax.is_led_run(rd):
         raise ValueError(
-            "This run doesn't look like an external trigger run, so better to avoid this plot."
+            "This run doesn't look like an LED run, so better to avoid this plot."
         )
 
     fig, ax = plt.subplots(figsize=(15, 5))

--- a/amstrax/auto_processing_new/process.py
+++ b/amstrax/auto_processing_new/process.py
@@ -115,12 +115,12 @@ class RunProcessor:
 
     def infer_special_modes(self, st):
 
-        # Check if there is led in the run_doc
-        if "ledcalibration" in self.run_doc.get('mode'):
+        ax = self.amstrax
+
+        if ax.is_led_run(self.run_doc):
             # Add the LEDCalibration plugin to the context
-            log.info("Detected LED calibration run.")
+            log.info(f"Detected LED calibration run from {ax.run_class_source(self.run_doc)}.")
             log.info("Adding LEDCalibration plugin to the context.")
-            ax = self.amstrax
             st.register([
                 ax.DAQReader,
                 ax.RecordsLED,
@@ -132,12 +132,13 @@ class RunProcessor:
             log.info(f"Overriding targets to {self.targets}")
         
 
-        if "_nai" in self.run_doc.get('mode'):
+        if ax.has_nai_source(self.run_doc):
             # Add the NAI plugin to the context
             # All the _ext plugins should be already in the context
-            log.info("Detected NaI run.")
+            log.info(f"Detected NaI run from {ax.source_type_source(self.run_doc)}.")
             log.info("Adding peak_basics_ext to list of targets to process.")
-            self.targets.append("peak_basics_ext")          
+            if "peak_basics_ext" not in self.targets:
+                self.targets.append("peak_basics_ext")
 
         return st
 

--- a/amstrax/run_metadata.py
+++ b/amstrax/run_metadata.py
@@ -84,4 +84,3 @@ def source_type_source(run_doc):
     if _lower_string(bookkeeping.get("source_type")):
         return "xams_bookkeeping.source_type"
     return "legacy mode fallback"
-

--- a/amstrax/run_metadata.py
+++ b/amstrax/run_metadata.py
@@ -1,0 +1,87 @@
+"""Helpers for interpreting XAMS run metadata.
+
+Structured rundoc bookkeeping is preferred, but the legacy mode strings remain
+as fallback because old runs and old start paths still rely on them.
+"""
+
+
+LED_RUN_CLASSES = ("led",)
+NAI_SOURCE_TYPES = ("nai", "nai22")
+LEGACY_LED_MODE_MARKERS = ("ledcalibration", "led_calibration", "led")
+LEGACY_NAI_MODE_MARKERS = ("_nai", "nai22")
+
+
+def _clean_string(value):
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _lower_string(value):
+    return _clean_string(value).lower()
+
+
+def _nested_dict(doc, key):
+    value = doc.get(key, {}) if isinstance(doc, dict) else {}
+    return value if isinstance(value, dict) else {}
+
+
+def get_run_mode(run_doc):
+    """Return the rundoc mode as a stripped string."""
+    return _clean_string(run_doc.get("mode") if isinstance(run_doc, dict) else "")
+
+
+def get_xams_bookkeeping(run_doc):
+    """Return xams_bookkeeping if present and dict-like, otherwise an empty dict."""
+    return _nested_dict(run_doc, "xams_bookkeeping")
+
+
+def get_run_class(run_doc):
+    """Return the structured run class if present, else a legacy mode fallback."""
+    bookkeeping = get_xams_bookkeeping(run_doc)
+    run_class = _lower_string(bookkeeping.get("run_class"))
+    if run_class:
+        return run_class
+
+    mode = _lower_string(get_run_mode(run_doc))
+    if any(marker in mode for marker in LEGACY_LED_MODE_MARKERS):
+        return "led"
+    return "science"
+
+
+def get_source_type(run_doc):
+    """Return the structured source type if present, else a legacy mode fallback."""
+    bookkeeping = get_xams_bookkeeping(run_doc)
+    source_type = _lower_string(bookkeeping.get("source_type"))
+    if source_type:
+        return source_type
+
+    mode = _lower_string(get_run_mode(run_doc))
+    if any(marker in mode for marker in LEGACY_NAI_MODE_MARKERS):
+        return "nai22"
+    return "none"
+
+
+def is_led_run(run_doc):
+    return get_run_class(run_doc) in LED_RUN_CLASSES
+
+
+def has_nai_source(run_doc):
+    return get_source_type(run_doc) in NAI_SOURCE_TYPES
+
+
+def run_class_source(run_doc):
+    """Describe whether run_class came from structured metadata or legacy mode."""
+    bookkeeping = get_xams_bookkeeping(run_doc)
+    if _lower_string(bookkeeping.get("run_class")):
+        return "xams_bookkeeping.run_class"
+    return "legacy mode fallback"
+
+
+def source_type_source(run_doc):
+    """Describe whether source_type came from structured metadata or legacy mode."""
+    bookkeeping = get_xams_bookkeeping(run_doc)
+    if _lower_string(bookkeeping.get("source_type")):
+        return "xams_bookkeeping.source_type"
+    return "legacy mode fallback"
+

--- a/tests/test_run_metadata.py
+++ b/tests/test_run_metadata.py
@@ -1,0 +1,64 @@
+import importlib.util
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "amstrax" / "run_metadata.py"
+SPEC = importlib.util.spec_from_file_location("run_metadata", MODULE_PATH)
+run_metadata = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(run_metadata)
+
+
+def test_structured_led_run_class_wins_over_mode():
+    run_doc = {
+        "mode": "tpc",
+        "xams_bookkeeping": {
+            "run_class": "led",
+        },
+    }
+
+    assert run_metadata.get_run_class(run_doc) == "led"
+    assert run_metadata.is_led_run(run_doc)
+    assert run_metadata.run_class_source(run_doc) == "xams_bookkeeping.run_class"
+
+
+def test_legacy_led_mode_is_kept_as_fallback():
+    run_doc = {"mode": "ext_trig_ledcalibration"}
+
+    assert run_metadata.get_run_class(run_doc) == "led"
+    assert run_metadata.is_led_run(run_doc)
+    assert run_metadata.run_class_source(run_doc) == "legacy mode fallback"
+
+
+def test_structured_source_type_wins_over_mode():
+    run_doc = {
+        "mode": "tpc",
+        "xams_bookkeeping": {
+            "source_type": "nai22",
+        },
+    }
+
+    assert run_metadata.get_source_type(run_doc) == "nai22"
+    assert run_metadata.has_nai_source(run_doc)
+    assert run_metadata.source_type_source(run_doc) == "xams_bookkeeping.source_type"
+
+
+def test_legacy_nai_mode_is_kept_as_fallback():
+    run_doc = {"mode": "tpc_nai"}
+
+    assert run_metadata.get_source_type(run_doc) == "nai22"
+    assert run_metadata.has_nai_source(run_doc)
+    assert run_metadata.source_type_source(run_doc) == "legacy mode fallback"
+
+
+def test_missing_or_malformed_metadata_is_safe():
+    run_doc = {
+        "mode": None,
+        "xams_bookkeeping": "not-a-dict",
+    }
+
+    assert run_metadata.get_run_mode(run_doc) == ""
+    assert run_metadata.get_run_class(run_doc) == "science"
+    assert run_metadata.get_source_type(run_doc) == "none"
+    assert not run_metadata.is_led_run(run_doc)
+    assert not run_metadata.has_nai_source(run_doc)
+

--- a/tests/test_run_metadata.py
+++ b/tests/test_run_metadata.py
@@ -61,4 +61,3 @@ def test_missing_or_malformed_metadata_is_safe():
     assert run_metadata.get_source_type(run_doc) == "none"
     assert not run_metadata.is_led_run(run_doc)
     assert not run_metadata.has_nai_source(run_doc)
-


### PR DESCRIPTION
## Summary
- add run metadata helpers that prefer xams_bookkeeping and keep legacy mode-string fallbacks
- route autoprocessing LED/NaI detection through the shared helper
- make LED plotting check LED metadata instead of ext_trig and avoid crashing on missing rundocs

## Validation
- python -m py_compile amstrax/run_metadata.py amstrax/auto_processing_new/process.py amstrax/analyses/plotting.py tests/test_run_metadata.py
- direct execution of tests/test_run_metadata.py test functions via importlib

Note: `python -m pytest -q tests/test_run_metadata.py` crashes locally with exit 139 before emitting output, so I validated the helper tests directly.