### PR TITLE
Fix/records led rundoc polarity sipm

### DIFF
--- a/amstrax/__init__.py
+++ b/amstrax/__init__.py
@@ -10,6 +10,9 @@ from .xams_config import *
 from . import corrections_services
 from .corrections_services import *
 
+from . import daq_config
+from .daq_config import *
+
 from . import plugins
 from .plugins import *
 

--- a/amstrax/contexts.py
+++ b/amstrax/contexts.py
@@ -155,10 +155,9 @@ def context_for_daq_reader(
     daq_config = run_doc["daq_config"]
     _set_optional_channel_map(st=st, run_doc=run_doc)
     input_dir = _resolve_input_dir_for_daq_reader(st=st, run_id=run_id, daq_config=daq_config)
-    channel_polarity_map = _extract_channel_polarity(daq_config['registers'])
 
     st.set_context_config(dict(forbid_creation_of=tuple()))
-    st.set_config(_build_daq_reader_config(run_doc=run_doc, daq_config=daq_config, input_dir=input_dir, channel_polarity_map=channel_polarity_map))
+    st.set_config(_build_daq_reader_config(run_doc=run_doc, daq_config=daq_config, input_dir=input_dir))
     UserWarning(f'You changed the context for {run_id}. Do not process any other run!')
     return st
 
@@ -206,27 +205,7 @@ def _resolve_input_dir_for_daq_reader(st: strax.Context, run_id: str, daq_config
     return input_dir
 
 
-def _extract_channel_polarity(registers) -> dict:
-    channel_polarity = {}
-    for reg in registers:
-        reg_addr = reg['reg'].lower()
-        reg_val = reg['val'].lower()
-        if not (reg_addr.startswith('1') and reg_addr.endswith('80')):
-            continue
-        try:
-            chan_num = (int(reg_addr, 16) - 0x1080) // 0x100
-            if reg_val in ("110000", "1110000"):
-                channel_polarity[chan_num] = -1
-            elif reg_val in ("100000", "1100000"):
-                channel_polarity[chan_num] = 1
-            else:
-                raise ValueError(f"Unknown polarity config value '{reg_val}' for channel {chan_num}")
-        except Exception as err:
-            print(f"Error parsing register {reg_addr} with value {reg_val}: {err}")
-    return channel_polarity
-
-
-def _build_daq_reader_config(run_doc: dict, daq_config: dict, input_dir: str, channel_polarity_map: dict) -> dict:
+def _build_daq_reader_config(run_doc: dict, daq_config: dict, input_dir: str) -> dict:
     return {
         'readout_threads': daq_config['processing_threads'],
         'daq_input_dir': input_dir,
@@ -236,13 +215,12 @@ def _build_daq_reader_config(run_doc: dict, daq_config: dict, input_dir: str, ch
         'daq_chunk_duration': int(daq_config['strax_chunk_length'] * 1e9),
         'daq_overlap_chunk_duration': int(daq_config['strax_chunk_overlap'] * 1e9),
         'compressor': daq_config.get('compressor', 'lz4'),
-        'channels_polarity': channel_polarity_map,
     }
 
 
 def xams_led(**kwargs):
     st = xams(**kwargs)
-    st.set_context_config({"check_available": ("raw_records", "records_led", "led_calibration")})
+    st.set_context_config({"check_available": ("raw_records", "raw_records_sipm", "records_led", "led_calibration")})
     # Return a new context with only raw_records and led_calibration registered
     st = st.new_context(replace=True, config=st.config, storage=st.storage, **st.context_config)
     st.register([ax.DAQReader, ax.RecordsLED, ax.LEDCalibration])

--- a/amstrax/daq_config.py
+++ b/amstrax/daq_config.py
@@ -1,0 +1,40 @@
+import typing as ty
+
+import numpy as np
+import strax
+
+export, __all__ = strax.exporter()
+
+
+@export
+def extract_channel_polarity(registers: ty.Iterable[dict]) -> dict:
+    """Extract CAEN channel polarity from per-channel DPP control registers."""
+    channel_polarity = {}
+    for reg in registers or []:
+        reg_addr = str(reg.get("reg", "")).lower()
+        reg_val = str(reg.get("val", "")).lower()
+        if not (reg_addr.startswith("1") and reg_addr.endswith("80")):
+            continue
+        try:
+            chan_num = (int(reg_addr, 16) - 0x1080) // 0x100
+            if reg_val in ("110000", "1110000"):
+                channel_polarity[chan_num] = -1
+            elif reg_val in ("100000", "1100000"):
+                channel_polarity[chan_num] = 1
+            else:
+                raise ValueError(f"Unknown polarity config value '{reg_val}' for channel {chan_num}")
+        except Exception as err:
+            print(f"Error parsing register {reg_addr} with value {reg_val}: {err}")
+    return channel_polarity
+
+
+@export
+def channels_in_map_group(channel_map: dict, group: str) -> set:
+    """Return integer channel numbers from a channel-map group."""
+    if not isinstance(channel_map, dict):
+        return set()
+    group_range = channel_map.get(group)
+    if not isinstance(group_range, (list, tuple)) or len(group_range) != 2:
+        return set()
+    left, right = (int(group_range[0]), int(group_range[1]))
+    return set(np.arange(left, right + 1, dtype=np.int64).tolist())

--- a/amstrax/daq_config.py
+++ b/amstrax/daq_config.py
@@ -1,4 +1,5 @@
 import typing as ty
+import json
 
 import numpy as np
 import strax
@@ -9,8 +10,21 @@ export, __all__ = strax.exporter()
 @export
 def extract_channel_polarity(registers: ty.Iterable[dict]) -> dict:
     """Extract CAEN channel polarity from per-channel DPP control registers."""
+    if isinstance(registers, str):
+        try:
+            registers = json.loads(registers)
+        except json.JSONDecodeError as err:
+            raise TypeError(
+                "DAQ registers must be a list of register dictionaries, not an unresolved string. "
+                "If this is a rundoc:// config, access it through the XAMSConfig descriptor."
+            ) from err
+    if isinstance(registers, dict):
+        registers = registers.values()
+
     channel_polarity = {}
     for reg in registers or []:
+        if not isinstance(reg, dict):
+            raise TypeError(f"DAQ register entries must be dictionaries, got {type(reg).__name__}: {reg!r}")
         reg_addr = str(reg.get("reg", "")).lower()
         reg_val = str(reg.get("val", "")).lower()
         if not (reg_addr.startswith("1") and reg_addr.endswith("80")):

--- a/amstrax/mini_analysis.py
+++ b/amstrax/mini_analysis.py
@@ -60,7 +60,7 @@ def mini_analysis(
 
                 to_pe = context.config["gain_model"]
                 if isinstance(to_pe, str):
-                    to_pe = strax.Config.evaluate_dry(to_pe, run_id=run_id)
+                    to_pe = amstrax.XAMSConfig.evaluate_dry(to_pe, run_id=run_id)
                 kwargs["to_pe"] = to_pe
 
             # Prepare selection arguments

--- a/amstrax/plugins/events/event_area_per_channel.py
+++ b/amstrax/plugins/events/event_area_per_channel.py
@@ -7,17 +7,15 @@ export, __all__ = strax.exporter()
 
 
 @export
-@strax.takes_config(
-    amstrax.XAMSConfig(
-        name="channel_map",
+class EventAreaPerChannel(strax.Plugin):
+    """Simple plugin that provides area per channel for main and alternative S1/S2 in the event."""
+
+    channel_map = amstrax.XAMSConfig(
         default="rundoc://?path=xams_bookkeeping.channel_map&fallback=xams_default",
         track=False,
         type=immutabledict,
         help="immutabledict mapping subdetector to (min, max), loaded from rundoc",
-    ),
-)
-class EventAreaPerChannel(strax.Plugin):
-    """Simple plugin that provides area per channel for main and alternative S1/S2 in the event."""
+    )
 
     depends_on = ("event_basics", "peaks")
     provides = ("event_area_per_channel", "event_n_channel")

--- a/amstrax/plugins/events/event_basics.py
+++ b/amstrax/plugins/events/event_basics.py
@@ -6,28 +6,6 @@ import amstrax
 export, __all__ = strax.exporter()
 
 
-@strax.takes_config(
-    strax.Option('electron_drift_velocity', default=1.6e-6, track=True,
-                  help='Vertical electron drift velocity in cm/ns (1e4 m/ms)'),
-    strax.Option('allow_posts2_s1s',
-                  default=False, infer_type=False,
-                  help="Allow S1s past the main S2 to become the main S1 and S2"),
-    strax.Option('force_main_before_alt',
-                  default=False, infer_type=False,
-                  help="Make the alternate S1 (and likewise S2) the main S1 if "
-                       "occurs before the main S1."),
-    strax.Option('force_alt_s2_in_max_drift_time',
-                  default=True, infer_type=False,
-                  help="Make sure alt_s2 is in max drift time starting from main S1"),
-    strax.Option('event_s1_min_coincidence',
-                  default=0, infer_type=False,
-                  help="Event level S1 min coincidence. Should be >= s1_min_coincidence "
-                       "in the peaklet classification"),
-    strax.Option('max_drift_length',
-                  default=amstrax.tpc_z, infer_type=False,
-                  help='Total length of the TPC from the bottom of gate to the '
-                       'top of cathode wires [cm]'),
-)
 @export
 class EventBasics(strax.Plugin):
     """
@@ -41,6 +19,31 @@ class EventBasics(strax.Plugin):
     in the time window [main S1 time, main S1 time + max drift time].
     """
     __version__ = '1.6'
+
+    electron_drift_velocity = amstrax.XAMSConfig(
+        default=1.6e-6,
+        track=True,
+        help='Vertical electron drift velocity in cm/ns (1e4 m/ms)')
+    allow_posts2_s1s = amstrax.XAMSConfig(
+        default=False,
+        infer_type=False,
+        help="Allow S1s past the main S2 to become the main S1 and S2")
+    force_main_before_alt = amstrax.XAMSConfig(
+        default=False,
+        infer_type=False,
+        help="Make the alternate S1 (and likewise S2) the main S1 if occurs before the main S1.")
+    force_alt_s2_in_max_drift_time = amstrax.XAMSConfig(
+        default=True,
+        infer_type=False,
+        help="Make sure alt_s2 is in max drift time starting from main S1")
+    event_s1_min_coincidence = amstrax.XAMSConfig(
+        default=0,
+        infer_type=False,
+        help="Event level S1 min coincidence. Should be >= s1_min_coincidence in the peaklet classification")
+    max_drift_length = amstrax.XAMSConfig(
+        default=amstrax.tpc_z,
+        infer_type=False,
+        help='Total length of the TPC from the bottom of gate to the top of cathode wires [cm]')
 
     depends_on = ('events',
                   'peak_basics',
@@ -115,14 +118,6 @@ class EventBasics(strax.Plugin):
         )
 
     def setup(self):
-        
-        self.electron_drift_velocity = self.config['electron_drift_velocity']
-        self.allow_posts2_s1s = self.config['allow_posts2_s1s']
-        self.force_main_before_alt = self.config['force_main_before_alt']
-        self.force_alt_s2_in_max_drift_time = self.config['force_alt_s2_in_max_drift_time']
-        self.event_s1_min_coincidence = self.config['event_s1_min_coincidence']
-        self.max_drift_length = self.config['max_drift_length']
-        
         self.drift_time_max = int(self.max_drift_length / self.electron_drift_velocity)
 
         
@@ -379,4 +374,3 @@ class EventBasics(strax.Plugin):
             res['s2_index'] = s2_idx[0]
             if len(s2_idx) > 1:
                 res['alt_s2_index'] = s2_idx[1]
-

--- a/amstrax/plugins/events/event_coincidences.py
+++ b/amstrax/plugins/events/event_coincidences.py
@@ -7,19 +7,6 @@ export, __all__ = strax.exporter()
 
 
 @export
-@strax.takes_config(
-        strax.Option(
-        "max_delay",
-        default=100,
-        help="Maximum allowed time difference between XAMS events and external peaks to count as a match, in ns",
-        ),
-        strax.Option(
-        "absorption_peak_delta",
-        default=65,
-        help="Sets the window as [511 - delta, 511 + delta] in keV for the allowed energies that count as an absorption event of a 511 keV photon in the external detector",
-        ),
-)
-
 class EventCoincidences(strax.OverlapWindowPlugin):
     """
     Some runs are taken with a na-22 source. This source emits two 511keV photons in exactly opposite directions.
@@ -27,6 +14,14 @@ class EventCoincidences(strax.OverlapWindowPlugin):
     which allows us to tag the XAMS events that are coincident with the external detector.
     This plugin provides a bool 'is_coinc' that is True if the event is coincident with that external detector.
     """
+    max_delay = amstrax.XAMSConfig(
+        default=100,
+        help="Maximum allowed time difference between XAMS events and external peaks to count as a match, in ns",
+    )
+    absorption_peak_delta = amstrax.XAMSConfig(
+        default=65,
+        help="Sets the window as [511 - delta, 511 + delta] in keV for the allowed energies that count as an absorption event of a 511 keV photon in the external detector",
+    )
 
     provides = ('event_coincidences',)
     depends_on = ('event_basics', 'peaks_ext',)

--- a/amstrax/plugins/events/event_positions.py
+++ b/amstrax/plugins/events/event_positions.py
@@ -10,21 +10,6 @@ export, __all__ = strax.exporter()
 
 
 @export
-@strax.takes_config(
-    strax.Option('default_reconstruction_algorithm',
-                 default=DEFAULT_POSREC_ALGO,
-                 help="default reconstruction algorithm that provides (x,y)"),
-    strax.Option('drift_time_gate',
-                 default=3000,
-                 help='Drift time belonging to the gate in ns'),
-    strax.Option('drift_time_cathode',
-                 default=39500,
-                 help='Drift time belonging to the cathode in ns'),
-    strax.Option('gate_cathode_distance',
-                 default=50.5,
-                 help='Distance between gate and cathode in mm'),    
-)
-
 class EventPositions(strax.Plugin):
     """
     Computes the observed and corrected position for the main S1/S2
@@ -38,6 +23,18 @@ class EventPositions(strax.Plugin):
 
     __version__ = '1.1.20'
 
+    default_reconstruction_algorithm = amstrax.XAMSConfig(
+        default=DEFAULT_POSREC_ALGO,
+        help="default reconstruction algorithm that provides (x,y)")
+    drift_time_gate = amstrax.XAMSConfig(
+        default=3000,
+        help='Drift time belonging to the gate in ns')
+    drift_time_cathode = amstrax.XAMSConfig(
+        default=39500,
+        help='Drift time belonging to the cathode in ns')
+    gate_cathode_distance = amstrax.XAMSConfig(
+        default=50.5,
+        help='Distance between gate and cathode in mm')
 
     def infer_dtype(self):
         dtype = []
@@ -54,13 +51,6 @@ class EventPositions(strax.Plugin):
         
         return dtype + strax.time_fields
 
-    def setup(self):
-
-        self.default_reconstruction_algorithm = self.config['default_reconstruction_algorithm']
-        self.drift_time_gate = self.config['drift_time_gate']
-        self.drift_time_cathode = self.config['drift_time_cathode']
-        self.gate_cathode_distance = self.config['gate_cathode_distance']
-        
     def compute(self, events):
 
         result = {'time': events['time'],

--- a/amstrax/plugins/events/events.py
+++ b/amstrax/plugins/events/events.py
@@ -1,21 +1,21 @@
+import amstrax
 import numba
 import numpy as np
 import strax
 export, __all__ = strax.exporter()
 
 @export
-@strax.takes_config(
-    strax.Option('trigger_min_area', default=10,
-                 help='Peaks must have more area (PE) than this to '
-                      'cause events'),
-    strax.Option('left_event_extension', default=int(5e5),
-                 help='Extend events this many ns to the left from each '
-                      'triggering peak'),
-    strax.Option('right_event_extension', default=int(5e4),
-                 help='Extend events this many ns to the right from each '
-                      'triggering peak'),
-)
 class Events(strax.OverlapWindowPlugin):
+    trigger_min_area = amstrax.XAMSConfig(
+        default=10,
+        help='Peaks must have more area (PE) than this to cause events')
+    left_event_extension = amstrax.XAMSConfig(
+        default=int(5e5),
+        help='Extend events this many ns to the left from each triggering peak')
+    right_event_extension = amstrax.XAMSConfig(
+        default=int(5e4),
+        help='Extend events this many ns to the right from each triggering peak')
+
     depends_on = ['peaks', 
                   'peak_basics',
                   ]
@@ -67,4 +67,3 @@ class Events(strax.OverlapWindowPlugin):
         self.events_seen += len(result)
 
         return result
-

--- a/amstrax/plugins/led_calibration/led_calibration.py
+++ b/amstrax/plugins/led_calibration/led_calibration.py
@@ -1,3 +1,4 @@
+import amstrax
 from immutabledict import immutabledict
 import strax
 import numba
@@ -7,16 +8,6 @@ export, __all__ = strax.exporter()
 
 
 @export
-@strax.takes_config(
-    strax.Option(
-        "led_window",
-        default=(80, 110),
-        help="Window (samples) where we expect the signal in LED calibration",
-    ),
-    strax.Option(
-        "noise_window", default=(0, 10), help="Window (samples) to analysis the noise"
-    ),
-)
 class LEDCalibration(strax.Plugin):
     """
     Preliminary version, several parameters to set during commissioning.
@@ -31,6 +22,13 @@ class LEDCalibration(strax.Plugin):
         - amplitudeNOISE: amplitude of the LED on run in a window far
           from the signal one.
     """
+    led_window = amstrax.XAMSConfig(
+        default=(80, 110),
+        help="Window (samples) where we expect the signal in LED calibration",
+    )
+    noise_window = amstrax.XAMSConfig(
+        default=(0, 10), help="Window (samples) to analysis the noise"
+    )
 
     __version__ = "1.0.0"
 
@@ -49,10 +47,6 @@ class LEDCalibration(strax.Plugin):
         ("dt", np.int16, "Time resolution in ns"),
         ("length", np.int32, "Length of the interval in samples"),
     ]
-
-    def setup(self):
-        self.led_window = self.config["led_window"]
-        self.noise_window = self.config["noise_window"]
 
     def compute(self, records_led):
         """

--- a/amstrax/plugins/led_calibration/records_led.py
+++ b/amstrax/plugins/led_calibration/records_led.py
@@ -1,6 +1,5 @@
 import strax
 import numpy as np
-from immutabledict import immutabledict
 
 import amstrax
 
@@ -28,14 +27,6 @@ export, __all__ = strax.exporter()
         help="DAQ register list from rundoc, used to infer channel polarity.",
     ),
 
-    amstrax.XAMSConfig(
-        name="channel_map",
-        default="rundoc://?path=xams_bookkeeping.channel_map&fallback=xams_default",
-        track=False,
-        type=immutabledict,
-        infer_type=False,
-        help="Channel map loaded from rundoc.",
-    ),
 )
 class RecordsLED(strax.Plugin):
     """
@@ -59,7 +50,6 @@ class RecordsLED(strax.Plugin):
         self.baseline_window = self.config['baseline_window']
         self.n_records_per_pulse = self.config['n_records_per_pulse']
         self.channel_polarity = amstrax.extract_channel_polarity(self.config['daq_registers'])
-        self.sipm_channels = amstrax.channels_in_map_group(self.config['channel_map'], 'sipm')
 
     def infer_dtype(self):
 
@@ -134,9 +124,7 @@ class RecordsLED(strax.Plugin):
         bl_hi = min(records["data"].shape[1], int(bl_hi))
         if bl_hi <= bl_lo:
             bl_lo, bl_hi = 0, min(50, records["data"].shape[1])
-        bl = records["data"][:, bl_lo:bl_hi].mean(axis=1)
-        records["data"] = -1.0 * (records["data"].transpose() - bl[:]).transpose()
-        self._restore_positive_polarity_channels(records)
+        self._baseline_and_flip(records, bl_lo=bl_lo, bl_hi=bl_hi)
 
         return records
 
@@ -149,13 +137,13 @@ class RecordsLED(strax.Plugin):
             return arrays[0]
         return strax.sort_by_time(np.concatenate(arrays))
 
-    def _restore_positive_polarity_channels(self, records):
-        """
-        records_led historically flips all channels after baselining.
-        Keep that PMT convention, but undo it for positive-polarity channels
-        and for channels explicitly marked as SiPM in the channel map.
-        """
-        for channel in np.unique(records["channel"]):
-            ch = int(channel)
-            if self.channel_polarity.get(ch) == 1 or ch in self.sipm_channels:
-                records["data"][records["channel"] == channel] *= -1.0
+    def _baseline_and_flip(self, records, bl_lo, bl_hi):
+        """Baseline records and flip only channels configured as negative polarity."""
+        for record in records:
+            length = int(max(0, min(record["length"], len(record["data"]))))
+            if length == 0:
+                continue
+            baseline = record["data"][bl_lo:bl_hi].mean()
+            sign = -1.0 if self.channel_polarity.get(int(record["channel"]), -1) == -1 else 1.0
+            record["data"][:length] = sign * (record["data"][:length] - baseline)
+            record["data"][length:] = 0.0

--- a/amstrax/plugins/led_calibration/records_led.py
+++ b/amstrax/plugins/led_calibration/records_led.py
@@ -6,34 +6,35 @@ import amstrax
 export, __all__ = strax.exporter()
 
 @export
-@strax.takes_config(
-
-    strax.Option('record_length', default=110, track=False, type=int,
-                 help="Number of samples per raw_record"),
-
-    strax.Option('baseline_window',
-        default=(0, 50), infer_type=False,
-        help="Window (samples) for baseline calculation."),
-
-    strax.Option('n_records_per_pulse',
-        default=2, type=int,
-        help="how many samples per pulse"),
-
-    amstrax.XAMSConfig(
-        name="daq_registers",
-        default="rundoc://?path=daq_config.registers&fallback=empty",
-        track=False,
-        infer_type=False,
-        help="DAQ register list from rundoc, used to infer channel polarity.",
-    ),
-
-)
 class RecordsLED(strax.Plugin):
     """
     Carlo needs to explain
     """
 
     __version__ = '1.1.0'
+
+    record_length = amstrax.XAMSConfig(
+        default=110,
+        track=False,
+        type=int,
+        help="Number of samples per raw_record",
+    )
+    baseline_window = amstrax.XAMSConfig(
+        default=(0, 50),
+        infer_type=False,
+        help="Window (samples) for baseline calculation.",
+    )
+    n_records_per_pulse = amstrax.XAMSConfig(
+        default=2,
+        type=int,
+        help="how many samples per pulse",
+    )
+    daq_registers = amstrax.XAMSConfig(
+        default="rundoc://?path=daq_config.registers&fallback=empty",
+        track=False,
+        infer_type=False,
+        help="DAQ register list from rundoc, used to infer channel polarity.",
+    )
 
     depends_on = ('raw_records', 'raw_records_sipm')
     data_kind = 'records_led'
@@ -46,11 +47,7 @@ class RecordsLED(strax.Plugin):
   
     def setup(self):
 
-        self.record_length = self.config['record_length']
-        self.baseline_window = self.config['baseline_window']
-        self.n_records_per_pulse = self.config['n_records_per_pulse']
-        daq_registers = self.takes_config["daq_registers"].__get__(self)
-        self.channel_polarity = amstrax.extract_channel_polarity(daq_registers)
+        self.channel_polarity = amstrax.extract_channel_polarity(self.daq_registers)
 
     def infer_dtype(self):
 

--- a/amstrax/plugins/led_calibration/records_led.py
+++ b/amstrax/plugins/led_calibration/records_led.py
@@ -1,5 +1,8 @@
 import strax
 import numpy as np
+from immutabledict import immutabledict
+
+import amstrax
 
 export, __all__ = strax.exporter()
 
@@ -16,15 +19,32 @@ export, __all__ = strax.exporter()
     strax.Option('n_records_per_pulse',
         default=2, type=int,
         help="how many samples per pulse"),
+
+    amstrax.XAMSConfig(
+        name="daq_registers",
+        default="rundoc://?path=daq_config.registers&fallback=empty",
+        track=False,
+        infer_type=False,
+        help="DAQ register list from rundoc, used to infer channel polarity.",
+    ),
+
+    amstrax.XAMSConfig(
+        name="channel_map",
+        default="rundoc://?path=xams_bookkeeping.channel_map&fallback=xams_default",
+        track=False,
+        type=immutabledict,
+        infer_type=False,
+        help="Channel map loaded from rundoc.",
+    ),
 )
 class RecordsLED(strax.Plugin):
     """
     Carlo needs to explain
     """
 
-    __version__ = '1.0.0'
+    __version__ = '1.1.0'
 
-    depends_on = ('raw_records',)
+    depends_on = ('raw_records', 'raw_records_sipm')
     data_kind = 'records_led'
     provides = 'records_led'
     compressor = 'zstd'
@@ -38,6 +58,8 @@ class RecordsLED(strax.Plugin):
         self.record_length = self.config['record_length']
         self.baseline_window = self.config['baseline_window']
         self.n_records_per_pulse = self.config['n_records_per_pulse']
+        self.channel_polarity = amstrax.extract_channel_polarity(self.config['daq_registers'])
+        self.sipm_channels = amstrax.channels_in_map_group(self.config['channel_map'], 'sipm')
 
     def infer_dtype(self):
 
@@ -51,10 +73,11 @@ class RecordsLED(strax.Plugin):
             
         return dtype 
 
-    def compute(self, raw_records):
+    def compute(self, raw_records, raw_records_sipm):
         '''
         Carlo needs to explain
         '''
+        raw_records = self._combine_raw_records(raw_records, raw_records_sipm)
         if len(raw_records) == 0:
             return np.zeros(0, dtype=self.dtype)
 
@@ -113,5 +136,26 @@ class RecordsLED(strax.Plugin):
             bl_lo, bl_hi = 0, min(50, records["data"].shape[1])
         bl = records["data"][:, bl_lo:bl_hi].mean(axis=1)
         records["data"] = -1.0 * (records["data"].transpose() - bl[:]).transpose()
+        self._restore_positive_polarity_channels(records)
 
         return records
+
+    @staticmethod
+    def _combine_raw_records(*raw_records):
+        arrays = [r for r in raw_records if len(r)]
+        if not arrays:
+            return raw_records[0]
+        if len(arrays) == 1:
+            return arrays[0]
+        return strax.sort_by_time(np.concatenate(arrays))
+
+    def _restore_positive_polarity_channels(self, records):
+        """
+        records_led historically flips all channels after baselining.
+        Keep that PMT convention, but undo it for positive-polarity channels
+        and for channels explicitly marked as SiPM in the channel map.
+        """
+        for channel in np.unique(records["channel"]):
+            ch = int(channel)
+            if self.channel_polarity.get(ch) == 1 or ch in self.sipm_channels:
+                records["data"][records["channel"] == channel] *= -1.0

--- a/amstrax/plugins/led_calibration/records_led.py
+++ b/amstrax/plugins/led_calibration/records_led.py
@@ -1,6 +1,4 @@
-from immutabledict import immutabledict
 import strax
-import numba
 import numpy as np
 
 export, __all__ = strax.exporter()
@@ -18,10 +16,6 @@ export, __all__ = strax.exporter()
     strax.Option('n_records_per_pulse',
         default=2, type=int,
         help="how many samples per pulse"),
-
-    strax.Option('record_length',
-        default=110, track=False, type=int,
-                 help="Number of samples per raw_record")
 )
 class RecordsLED(strax.Plugin):
     """
@@ -61,27 +55,63 @@ class RecordsLED(strax.Plugin):
         '''
         Carlo needs to explain
         '''
+        if len(raw_records) == 0:
+            return np.zeros(0, dtype=self.dtype)
 
-        record_length = np.shape(raw_records.dtype['data'])[0]
-        n_record_i = np.max(raw_records['record_i'])+1
-        num_channels = int(len(np.unique(raw_records['channel'])))
+        # Group fragments by pulse start time + channel.
+        # This is robust to variable record_i multiplicity per pulse/channel.
+        rec_len = int(np.shape(raw_records.dtype["data"])[0])
+        dt = raw_records["dt"].astype(np.int64)
+        rec_i = raw_records["record_i"].astype(np.int64)
+        pulse_start = raw_records["time"].astype(np.int64) - rec_i * rec_len * dt
+        group_keys = np.core.records.fromarrays(
+            [pulse_start, raw_records["channel"]],
+            names="pulse_start,channel",
+        )
+        _, group_first_idx, group_inverse = np.unique(
+            group_keys, return_index=True, return_inverse=True
+        )
 
-        records = np.zeros(int(len(raw_records)/n_record_i), dtype=self.dtype)
+        records = np.zeros(len(group_first_idx), dtype=self.dtype)
+        out_wave_len = self.dtype["data"].shape[0]
 
-        datas = [raw_records[np.where(raw_records['record_i'] == i)[0]] for i in range(n_record_i)]
+        for out_i in range(len(group_first_idx)):
+            idx = np.where(group_inverse == out_i)[0]
+            fragments = raw_records[idx]
+            order = np.argsort(fragments["record_i"], kind="stable")
+            fragments = fragments[order]
 
-        for i, name in enumerate(raw_records.dtype.names):
-            if name == 'data':  
-                records[name] = np.hstack(list(datas[i][name] for i in range(n_record_i)))
-            if name == 'length':
-                records[name] = np.sum(list(datas[i][name] for i in range(n_record_i)), axis=0)
-            else:
-                try:
-                    records[name] = datas[0][name]
-                except:
-                    pass
-        
-        bl = records['data'][:, self.baseline_window[0]:self.baseline_window[1]].mean(axis=1)
-        records['data'] = -1. * (records['data'].transpose() - bl[:]).transpose()
+            # Copy scalar/meta fields from first fragment
+            first = fragments[0]
+            records[out_i]["time"] = first["time"]
+            records[out_i]["dt"] = first["dt"]
+            records[out_i]["channel"] = first["channel"]
+            records[out_i]["pulse_length"] = np.max(fragments["pulse_length"])
+            records[out_i]["record_i"] = 0
+
+            # Concatenate variable fragment waveforms, then truncate/pad to fixed LED size.
+            parts = []
+            total_length = 0
+            for frag in fragments:
+                frag_len = int(max(0, min(rec_len, frag["length"])))
+                if frag_len == 0:
+                    continue
+                piece = frag["data"][:frag_len].astype(np.float32, copy=False)
+                parts.append(piece)
+                total_length += frag_len
+
+            if parts:
+                wf = np.concatenate(parts)
+                clip_len = min(len(wf), out_wave_len)
+                records[out_i]["data"][:clip_len] = wf[:clip_len]
+            records[out_i]["length"] = min(total_length, out_wave_len)
+
+        bl_lo, bl_hi = self.baseline_window
+        bl_lo = max(0, int(bl_lo))
+        bl_hi = min(records["data"].shape[1], int(bl_hi))
+        if bl_hi <= bl_lo:
+            bl_lo, bl_hi = 0, min(50, records["data"].shape[1])
+        bl = records["data"][:, bl_lo:bl_hi].mean(axis=1)
+        records["data"] = -1.0 * (records["data"].transpose() - bl[:]).transpose()
 
         return records

--- a/amstrax/plugins/led_calibration/records_led.py
+++ b/amstrax/plugins/led_calibration/records_led.py
@@ -49,7 +49,8 @@ class RecordsLED(strax.Plugin):
         self.record_length = self.config['record_length']
         self.baseline_window = self.config['baseline_window']
         self.n_records_per_pulse = self.config['n_records_per_pulse']
-        self.channel_polarity = amstrax.extract_channel_polarity(self.daq_registers)
+        daq_registers = self.takes_config["daq_registers"].__get__(self)
+        self.channel_polarity = amstrax.extract_channel_polarity(daq_registers)
 
     def infer_dtype(self):
 

--- a/amstrax/plugins/led_calibration/records_led.py
+++ b/amstrax/plugins/led_calibration/records_led.py
@@ -49,7 +49,7 @@ class RecordsLED(strax.Plugin):
         self.record_length = self.config['record_length']
         self.baseline_window = self.config['baseline_window']
         self.n_records_per_pulse = self.config['n_records_per_pulse']
-        self.channel_polarity = amstrax.extract_channel_polarity(self.config['daq_registers'])
+        self.channel_polarity = amstrax.extract_channel_polarity(self.daq_registers)
 
     def infer_dtype(self):
 

--- a/amstrax/plugins/peaks/peak_basics.py
+++ b/amstrax/plugins/peaks/peak_basics.py
@@ -9,67 +9,6 @@ export, __all__ = strax.exporter()
 
 # For n_competing, which is temporarily added to PeakBasics
 @export
-@strax.takes_config(
-    amstrax.XAMSConfig(
-        name="channel_map",
-        default="rundoc://?path=xams_bookkeeping.channel_map&fallback=xams_default",
-        type=immutabledict,
-        track=False,
-        help="Map of channel groups loaded from rundoc xams_bookkeeping.channel_map",
-    ),
-    strax.Option(
-        "check_peak_sum_area_rtol",
-        default=1e-4,
-        help="Check if the area of the sum-wf is the same as the total area"
-        " (if the area of the peak is positively defined)."
-        " Set to None to disable.",
-    ),
-    strax.Option(
-      's1_min_width', 
-      default=10,
-      help="Minimum (IQR) width of S1s"
-    ),
-    strax.Option(
-      's1_max_width',
-      default=225,
-      help="Maximum (IQR) width of S1s"
-    ),
-    strax.Option(
-      's1_min_area',
-      default=10,
-      help="Minimum area (PE) for S1s"
-    ),
-    strax.Option(
-      's2_min_area',
-      default=10,
-      help="Minimum area (PE) for S2s"
-    ),
-    strax.Option(
-      's2_min_width',
-      default=225,
-      help="Minimum width for S2s"
-    ),
-    strax.Option(
-      's1_min_channels',
-      default=5,
-      help="Minimum number of channels for S1s"
-    ),
-    strax.Option(
-      's2_min_channels',
-      default=5,
-      help="Minimum number of channels for S2s"
-    ),
-    strax.Option(
-      's2_min_area_fraction_top',
-      default=0,
-      help="Minimum area fraction top for S2s"
-    ),
-    strax.Option(
-      's1_max_area_fraction_top',
-      default=.2,
-      help="Maximum area fraction top for S1s"
-    ),
-)
 class PeakBasics(strax.Plugin):
     provides = ("peak_basics",)
     depends_on = ("peaks", )
@@ -78,6 +17,31 @@ class PeakBasics(strax.Plugin):
     parallel = "False"
     rechunk_on_save = False
     __version__ = "2.1"
+    channel_map = amstrax.XAMSConfig(
+        default="rundoc://?path=xams_bookkeeping.channel_map&fallback=xams_default",
+        type=immutabledict,
+        track=False,
+        help="Map of channel groups loaded from rundoc xams_bookkeeping.channel_map",
+    )
+    check_peak_sum_area_rtol = amstrax.XAMSConfig(
+        default=1e-4,
+        help="Check if the area of the sum-wf is the same as the total area"
+        " (if the area of the peak is positively defined)."
+        " Set to None to disable.",
+    )
+    s1_min_width = amstrax.XAMSConfig(default=10, help="Minimum (IQR) width of S1s")
+    s1_max_width = amstrax.XAMSConfig(default=225, help="Maximum (IQR) width of S1s")
+    s1_min_area = amstrax.XAMSConfig(default=10, help="Minimum area (PE) for S1s")
+    s2_min_area = amstrax.XAMSConfig(default=10, help="Minimum area (PE) for S2s")
+    s2_min_width = amstrax.XAMSConfig(default=225, help="Minimum width for S2s")
+    s1_min_channels = amstrax.XAMSConfig(
+        default=5, help="Minimum number of channels for S1s")
+    s2_min_channels = amstrax.XAMSConfig(
+        default=5, help="Minimum number of channels for S2s")
+    s2_min_area_fraction_top = amstrax.XAMSConfig(
+        default=0, help="Minimum area fraction top for S2s")
+    s1_max_area_fraction_top = amstrax.XAMSConfig(
+        default=.2, help="Maximum area fraction top for S1s")
     dtype = [
         (('Start time of the peak (ns since unix epoch)',
           'time'), np.int64),
@@ -135,7 +99,7 @@ class PeakBasics(strax.Plugin):
 
         # channel map is something like this
         # {'bottom': (0, 0), 'top': (1, 4), 'aqmon': (40, 40)}
-        channel_map = self.config['channel_map']
+        channel_map = self.channel_map
         top_pmt_indices = channel_map['top']
         bottom_pmt_indices = channel_map['bottom']
 

--- a/amstrax/plugins/peaks/peak_coincidences.py
+++ b/amstrax/plugins/peaks/peak_coincidences.py
@@ -1,3 +1,4 @@
+import amstrax
 import numba
 import numpy as np
 import strax
@@ -5,18 +6,6 @@ from immutabledict import immutabledict
 export, __all__ = strax.exporter()
 
 @export
-@strax.takes_config(
-        strax.Option(
-        "max_delay",
-        default=100,
-        help="Maximum allowed time difference between XAMS peaks and external peaks to count as a match, in ns",
-        ),
-        strax.Option(
-        "absorption_peak_delta",
-        default=65,
-        help="Sets the window as [511 - delta, 511 + delta] in keV for the allowed energies that count as an absorption event of a 511 keV photon in the external detector",
-        ),
-)
 class PeakCoincidences(strax.OverlapWindowPlugin):
     """
     Some runs are taken with a na-22 source. This source emits two 511keV photons in exactly opposite directions.
@@ -24,6 +13,14 @@ class PeakCoincidences(strax.OverlapWindowPlugin):
     which allows us to tag the XAMS peaks that are coincident with the external detector.
     This plugin provides a bool 'is_coinc' that is True if the peak is coincident with that external detector.
     """
+    max_delay = amstrax.XAMSConfig(
+        default=100,
+        help="Maximum allowed time difference between XAMS peaks and external peaks to count as a match, in ns",
+    )
+    absorption_peak_delta = amstrax.XAMSConfig(
+        default=65,
+        help="Sets the window as [511 - delta, 511 + delta] in keV for the allowed energies that count as an absorption event of a 511 keV photon in the external detector",
+    )
 
     provides = ('peak_coincidences',)
     depends_on = ('peaks', 'peaks_ext',)

--- a/amstrax/plugins/peaks/peak_positions.py
+++ b/amstrax/plugins/peaks/peak_positions.py
@@ -9,19 +9,6 @@ export, __all__ = strax.exporter()
 DEFAULT_POSREC_ALGO = 'corr'
 
 @export
-@strax.takes_config(
-    amstrax.XAMSConfig(
-        name="channel_map",
-        default="rundoc://?path=xams_bookkeeping.channel_map&fallback=xams_default",
-        type=immutabledict,
-        track=False,
-        help="Map of channel groups loaded from rundoc xams_bookkeeping.channel_map",
-    ),
-    strax.Option('default_reconstruction_algorithm',
-                 default=DEFAULT_POSREC_ALGO,
-                 help="default reconstruction algorithm that provides (x,y)"
-    )
-)
 class PeakPositions(strax.Plugin):
     depends_on = ('peaks', 'peak_basics')
     rechunk_on_save = False
@@ -49,6 +36,16 @@ class PeakPositions(strax.Plugin):
         ('endtime', np.int64, 'End time of the peak (ns since unix epoch)')
     ]
 
+    channel_map = amstrax.XAMSConfig(
+        default="rundoc://?path=xams_bookkeeping.channel_map&fallback=xams_default",
+        type=immutabledict,
+        track=False,
+        help="Map of channel groups loaded from rundoc xams_bookkeeping.channel_map",
+    )
+    default_reconstruction_algorithm = amstrax.XAMSConfig(
+        default=DEFAULT_POSREC_ALGO,
+        help="default reconstruction algorithm that provides (x,y)"
+    )
     pos_rec_params = amstrax.XAMSConfig(
         default=[
             [212.89988642, -320.95097295, 198.71830514, -46.03953999],
@@ -56,10 +53,6 @@ class PeakPositions(strax.Plugin):
         ],
         help="Parameters for a correction function to go from x_cgr to true x and y_cgr to true y"
     )
-
-    def setup(self):
-        
-        self.default_reconstruction_algorithm = self.config['default_reconstruction_algorithm']
 
     def compute(self, peaks):
                 
@@ -70,7 +63,7 @@ class PeakPositions(strax.Plugin):
         top_sum = peaks['area']*peaks['area_fraction_top']
 
         # top is going to be (1,4)
-        top_map = self.config['channel_map']['top']
+        top_map = self.channel_map['top']
         top_indeces = np.arange(top_map[0], top_map[1]+1)
 
         # a bit convoluted, but necessary to avoid division by zero

--- a/amstrax/plugins/peaks/peaks.py
+++ b/amstrax/plugins/peaks/peaks.py
@@ -7,8 +7,7 @@ export, __all__ = strax.exporter()
 
 # These are also needed in peaklets, since hitfinding is repeated
 HITFINDER_OPTIONS = tuple([
-    strax.Option(
-        'hit_min_amplitude',
+    amstrax.XAMSConfig(
         default='pmt_commissioning_initial',
         help='Minimum hit amplitude in ADC counts above baseline. '
              'See straxen.hit_min_amplitude for options.'
@@ -16,26 +15,6 @@ HITFINDER_OPTIONS = tuple([
 
 
 @export
-@strax.takes_config(
-    strax.Option('peak_gap_threshold', default=300,
-                 help="No hits for this many ns triggers a new peak"),
-    strax.Option('peak_left_extension', default=10,
-                 help="Include this many ns left of hits in peaks"),
-    strax.Option('peak_right_extension', default=10,
-                 help="Include this many ns right of hits in peaks"),
-    strax.Option('peak_min_area', default=10,
-                 help="Minimum contributing PMTs needed to define a peak"),
-    strax.Option('peak_min_pmts', default=1,
-                 help="Minimum contributing PMTs needed to define a peak"),
-    strax.Option('peak_split_min_height', default=25,
-                 help="Minimum height in PE above a local sum waveform"
-                      "minimum, on either side, to trigger a split"),
-    strax.Option('peak_split_min_ratio', default=4,
-                 help="Minimum ratio between local sum waveform"
-                      "minimum and maxima on either side, to trigger a split"),
-    strax.Option('n_tpc_pmts', track=False, default=False,
-                 help="Number of channels")
-)
 class Peaks(strax.Plugin):
     depends_on = ('records',)
     data_kind = 'peaks'
@@ -45,6 +24,32 @@ class Peaks(strax.Plugin):
 
     __version__ = '0.1.50'
 
+    peak_gap_threshold = amstrax.XAMSConfig(
+        default=300,
+        help="No hits for this many ns triggers a new peak")
+    peak_left_extension = amstrax.XAMSConfig(
+        default=10,
+        help="Include this many ns left of hits in peaks")
+    peak_right_extension = amstrax.XAMSConfig(
+        default=10,
+        help="Include this many ns right of hits in peaks")
+    peak_min_area = amstrax.XAMSConfig(
+        default=10,
+        help="Minimum contributing PMTs needed to define a peak")
+    peak_min_pmts = amstrax.XAMSConfig(
+        default=1,
+        help="Minimum contributing PMTs needed to define a peak")
+    peak_split_min_height = amstrax.XAMSConfig(
+        default=25,
+        help="Minimum height in PE above a local sum waveform"
+        "minimum, on either side, to trigger a split")
+    peak_split_min_ratio = amstrax.XAMSConfig(
+        default=4,
+        help="Minimum ratio between local sum waveform"
+        "minimum and maxima on either side, to trigger a split")
+    n_tpc_pmts = amstrax.XAMSConfig(
+        track=False, default=False,
+        help="Number of channels")
     gain_to_pe_array = amstrax.XAMSConfig(
         default=None,
         help="Gain to pe array"

--- a/amstrax/plugins/peaks_ext/peak_basics_ext.py
+++ b/amstrax/plugins/peaks_ext/peak_basics_ext.py
@@ -1,3 +1,4 @@
+import amstrax
 import numba
 import numpy as np
 import strax
@@ -8,23 +9,6 @@ export, __all__ = strax.exporter()
 
 # For n_competing, which is temporarily added to PeakBasics
 @export
-@strax.takes_config(
-    strax.Option(
-      's1_min_width', 
-      default=10,
-      help="Minimum (IQR) width of S1s"
-    ),
-    strax.Option(
-      's1_max_width',
-      default=225,
-      help="Maximum (IQR) width of S1s"
-    ),
-    strax.Option(
-      's2_min_width',
-      default=225,
-      help="Minimum width for S2s"
-    )
-)
 class PeakBasicsEXT(strax.Plugin):
     provides = ("peak_basics_ext",)
     depends_on = ("peaks_ext", )
@@ -33,6 +17,9 @@ class PeakBasicsEXT(strax.Plugin):
     parallel = "False"
     rechunk_on_save = False
     __version__ = "2.1"
+    s1_min_width = amstrax.XAMSConfig(default=10, help="Minimum (IQR) width of S1s")
+    s1_max_width = amstrax.XAMSConfig(default=225, help="Maximum (IQR) width of S1s")
+    s2_min_width = amstrax.XAMSConfig(default=225, help="Minimum width for S2s")
     dtype = [
         (('Start time of the peak (ns since unix epoch)',
           'time'), np.int64),

--- a/amstrax/plugins/peaks_ext/peak_basics_sipm.py
+++ b/amstrax/plugins/peaks_ext/peak_basics_sipm.py
@@ -9,67 +9,6 @@ export, __all__ = strax.exporter()
 
 # For n_competing, which is temporarily added to PeakBasics
 @export
-@strax.takes_config(
-    amstrax.XAMSConfig(
-        name="channel_map",
-        default="rundoc://?path=xams_bookkeeping.channel_map&fallback=xams_default",
-        type=immutabledict,
-        track=False,
-        help="Map of channel groups loaded from rundoc xams_bookkeeping.channel_map",
-    ),
-    strax.Option(
-        "check_peak_sum_area_rtol",
-        default=1e-4,
-        help="Check if the area of the sum-wf is the same as the total area"
-        " (if the area of the peak is positively defined)."
-        " Set to None to disable.",
-    ),
-    strax.Option(
-      's1_min_width', 
-      default=10,
-      help="Minimum (IQR) width of S1s"
-    ),
-    strax.Option(
-      's1_max_width',
-      default=225,
-      help="Maximum (IQR) width of S1s"
-    ),
-    strax.Option(
-      's1_min_area',
-      default=10,
-      help="Minimum area (PE) for S1s"
-    ),
-    strax.Option(
-      's2_min_area',
-      default=10,
-      help="Minimum area (PE) for S2s"
-    ),
-    strax.Option(
-      's2_min_width',
-      default=225,
-      help="Minimum width for S2s"
-    ),
-    strax.Option(
-      's1_min_channels',
-      default=5,
-      help="Minimum number of channels for S1s"
-    ),
-    strax.Option(
-      's2_min_channels',
-      default=5,
-      help="Minimum number of channels for S2s"
-    ),
-    strax.Option(
-      's2_min_area_fraction_top',
-      default=0,
-      help="Minimum area fraction top for S2s"
-    ),
-    strax.Option(
-      's1_max_area_fraction_top',
-      default=.2,
-      help="Maximum area fraction top for S1s"
-    ),
-)
 class PeakBasicsSiPM(strax.Plugin):
     provides = ("peak_basics_sipm",)
     depends_on = ("peaks_sipm", )
@@ -78,6 +17,31 @@ class PeakBasicsSiPM(strax.Plugin):
     parallel = "False"
     rechunk_on_save = False
     __version__ = "2.1"
+    channel_map = amstrax.XAMSConfig(
+        default="rundoc://?path=xams_bookkeeping.channel_map&fallback=xams_default",
+        type=immutabledict,
+        track=False,
+        help="Map of channel groups loaded from rundoc xams_bookkeeping.channel_map",
+    )
+    check_peak_sum_area_rtol = amstrax.XAMSConfig(
+        default=1e-4,
+        help="Check if the area of the sum-wf is the same as the total area"
+        " (if the area of the peak is positively defined)."
+        " Set to None to disable.",
+    )
+    s1_min_width = amstrax.XAMSConfig(default=10, help="Minimum (IQR) width of S1s")
+    s1_max_width = amstrax.XAMSConfig(default=225, help="Maximum (IQR) width of S1s")
+    s1_min_area = amstrax.XAMSConfig(default=10, help="Minimum area (PE) for S1s")
+    s2_min_area = amstrax.XAMSConfig(default=10, help="Minimum area (PE) for S2s")
+    s2_min_width = amstrax.XAMSConfig(default=225, help="Minimum width for S2s")
+    s1_min_channels = amstrax.XAMSConfig(
+        default=5, help="Minimum number of channels for S1s")
+    s2_min_channels = amstrax.XAMSConfig(
+        default=5, help="Minimum number of channels for S2s")
+    s2_min_area_fraction_top = amstrax.XAMSConfig(
+        default=0, help="Minimum area fraction top for S2s")
+    s1_max_area_fraction_top = amstrax.XAMSConfig(
+        default=.2, help="Maximum area fraction top for S1s")
     dtype = [
         (('Start time of the peak (ns since unix epoch)',
           'time'), np.int64),

--- a/amstrax/plugins/peaks_ext/peaks_ext.py
+++ b/amstrax/plugins/peaks_ext/peaks_ext.py
@@ -6,26 +6,6 @@ import amstrax
 export, __all__ = strax.exporter()
 
 @export
-@strax.takes_config(
-    strax.Option('peak_gap_threshold', default=300,
-                 help="No hits for this many ns triggers a new peak"),
-    strax.Option('peak_left_extension', default=10,
-                 help="Include this many ns left of hits in peaks"),
-    strax.Option('peak_right_extension', default=10,
-                 help="Include this many ns right of hits in peaks"),
-    strax.Option('peak_min_area', default=10,
-                 help="Minimum contributing PMTs needed to define a peak"),
-    strax.Option('peak_split_min_height', default=25,
-                 help="Minimum height in PE above a local sum waveform"
-                      "minimum, on either side, to trigger a split"),
-    strax.Option('peak_split_min_ratio', default=4,
-                 help="Minimum ratio between local sum waveform"
-                      "minimum and maxima on either side, to trigger a split"),
-    strax.Option('n_tpc_pmts', track=False, default=False,
-                 help="Number of channels"), 
-    strax.Option('n_ext_pmts', track=True, default=1,
-                    help="Number of external channels"),
-)
 class PeaksEXT(strax.Plugin):
     depends_on = ('records_ext',)
     data_kind = 'peaks_ext'
@@ -35,6 +15,32 @@ class PeaksEXT(strax.Plugin):
 
     __version__ = '0.0.3'
 
+    peak_gap_threshold = amstrax.XAMSConfig(
+        default=300,
+        help="No hits for this many ns triggers a new peak")
+    peak_left_extension = amstrax.XAMSConfig(
+        default=10,
+        help="Include this many ns left of hits in peaks")
+    peak_right_extension = amstrax.XAMSConfig(
+        default=10,
+        help="Include this many ns right of hits in peaks")
+    peak_min_area = amstrax.XAMSConfig(
+        default=10,
+        help="Minimum contributing PMTs needed to define a peak")
+    peak_split_min_height = amstrax.XAMSConfig(
+        default=25,
+        help="Minimum height in PE above a local sum waveform"
+        "minimum, on either side, to trigger a split")
+    peak_split_min_ratio = amstrax.XAMSConfig(
+        default=4,
+        help="Minimum ratio between local sum waveform"
+        "minimum and maxima on either side, to trigger a split")
+    n_tpc_pmts = amstrax.XAMSConfig(
+        track=False, default=False,
+        help="Number of channels")
+    n_ext_pmts = amstrax.XAMSConfig(
+        track=True, default=1,
+        help="Number of external channels")
     gain_to_pe_array = amstrax.XAMSConfig(
         default=None,
         help="Gain to pe array"
@@ -50,7 +56,7 @@ class PeaksEXT(strax.Plugin):
 
         r = records_ext
   
-        if self.config['gain_to_pe_array'] is None:
+        if self.gain_to_pe_array is None:
             self.to_pe = np.ones(self.config['n_ext_pmts']+self.config['n_tpc_pmts'])
         else:
             self.to_pe = self.gain_to_pe_array

--- a/amstrax/plugins/peaks_ext/peaks_sipm.py
+++ b/amstrax/plugins/peaks_ext/peaks_sipm.py
@@ -6,28 +6,6 @@ import amstrax
 export, __all__ = strax.exporter()
 
 @export
-@strax.takes_config(
-    strax.Option('peak_gap_threshold', default=300,
-                 help="No hits for this many ns triggers a new peak"),
-    strax.Option('peak_left_extension', default=10,
-                 help="Include this many ns left of hits in peaks"),
-    strax.Option('peak_right_extension', default=10,
-                 help="Include this many ns right of hits in peaks"),
-    strax.Option('peak_min_area', default=10,
-                 help="Minimum contributing PMTs needed to define a peak"),
-    strax.Option('peak_split_min_height', default=25,
-                 help="Minimum height in PE above a local sum waveform"
-                      "minimum, on either side, to trigger a split"),
-    strax.Option('peak_split_min_ratio', default=4,
-                 help="Minimum ratio between local sum waveform"
-                      "minimum and maxima on either side, to trigger a split"),
-    strax.Option('n_tpc_pmts', track=False, default=False,
-                 help="Number of channels"), 
-    strax.Option('n_ext_pmts', track=True, default=1,
-                    help="Number of external channels"),
-    strax.Option('n_sipms', track=True, default=1,
-                    help="Number of external channels"),
-)
 class PeaksSiPM(strax.Plugin):
     depends_on = ('records_sipm',)
     data_kind = 'peaks_sipm'
@@ -37,6 +15,35 @@ class PeaksSiPM(strax.Plugin):
 
     __version__ = '0.0.2'
 
+    peak_gap_threshold = amstrax.XAMSConfig(
+        default=300,
+        help="No hits for this many ns triggers a new peak")
+    peak_left_extension = amstrax.XAMSConfig(
+        default=10,
+        help="Include this many ns left of hits in peaks")
+    peak_right_extension = amstrax.XAMSConfig(
+        default=10,
+        help="Include this many ns right of hits in peaks")
+    peak_min_area = amstrax.XAMSConfig(
+        default=10,
+        help="Minimum contributing PMTs needed to define a peak")
+    peak_split_min_height = amstrax.XAMSConfig(
+        default=25,
+        help="Minimum height in PE above a local sum waveform"
+        "minimum, on either side, to trigger a split")
+    peak_split_min_ratio = amstrax.XAMSConfig(
+        default=4,
+        help="Minimum ratio between local sum waveform"
+        "minimum and maxima on either side, to trigger a split")
+    n_tpc_pmts = amstrax.XAMSConfig(
+        track=False, default=False,
+        help="Number of channels")
+    n_ext_pmts = amstrax.XAMSConfig(
+        track=True, default=1,
+        help="Number of external channels")
+    n_sipms = amstrax.XAMSConfig(
+        track=True, default=1,
+        help="Number of external channels")
     gain_to_pe_array = amstrax.XAMSConfig(
         default=None,
         help="Gain to pe array"
@@ -52,7 +59,7 @@ class PeaksSiPM(strax.Plugin):
 
         r = records_sipm
   
-        if self.config['gain_to_pe_array'] is None:
+        if self.gain_to_pe_array is None:
             #FIXME -> numba doesn't like a NumPy array inside a NumPy array, so this will fail in strax.find_peaks()
             self.to_pe = np.ones(self.config['n_ext_pmts']+self.config['n_tpc_pmts']+self.config['n_sipms'], dtype=np.float32)
         else:

--- a/amstrax/plugins/raw_records/daqreader.py
+++ b/amstrax/plugins/raw_records/daqreader.py
@@ -23,77 +23,6 @@ class ArtificialDeadtimeInserted(UserWarning):
 
 
 @export
-@strax.takes_config(
-    # All these must have track=False, so the raw_records hash never changes!
-    # DAQ settings -- should match settings given to redax
-    strax.Option(
-        "record_length", default=110, track=False, type=int, help="Number of samples per raw_record"
-    ),
-    strax.Option(
-        "max_digitizer_sampling_time",
-        default=10,
-        track=False,
-        type=int,
-        help="Highest interval time of the digitizer sampling times(s) used.",
-    ),
-    strax.Option(
-        "run_start_time",
-        type=float,
-        track=False,
-        default=0,
-        help="time of start run (s since unix epoch)",
-    ),
-    strax.Option(
-        "daq_chunk_duration",
-        track=False,
-        default=int(5e9),
-        type=int,
-        help="Duration of regular chunks in ns",
-    ),
-    strax.Option(
-        "daq_overlap_chunk_duration",
-        track=False,
-        default=int(5e8),
-        type=int,
-        help="Duration of intermediate/overlap chunks in ns",
-    ),
-    strax.Option(
-        "daq_compressor",
-        default="lz4",
-        track=False,
-        help="Algorithm used for (de)compressing the live data",
-    ),
-    strax.Option(
-        "readout_threads",
-        type=dict,
-        track=False,
-        help=(
-            "Dictionary of the readout threads where the keys "
-            "specify the reader and value the number of threads"
-        ),
-    ),
-    strax.Option("daq_input_dir", type=str, track=False, help="Directory where readers put data"),
-    # DAQReader settings
-    strax.Option(
-        "safe_break_in_pulses",
-        default=1000,
-        track=False,
-        infer_type=False,
-        help=(
-            "Time (ns) between pulses indicating a safe break "
-            "in the datastream -- gaps of this size cannot be "
-            "interior to peaklets."
-        ),
-    ),
-    amstrax.XAMSConfig(
-        name="channel_map",
-        default="rundoc://?path=xams_bookkeeping.channel_map&fallback=xams_default",
-        track=False,
-        type=immutabledict,
-        infer_type=False,
-        help="immutabledict mapping subdetector to (min, max), loaded from rundoc",
-    ),
-)
 class DAQReader(strax.Plugin):
     """Read the XENONnT DAQ-live_data from redax and split it to the appropriate raw_record data-
     types based on the channel-map.
@@ -109,7 +38,7 @@ class DAQReader(strax.Plugin):
 
     provides: Tuple[str, ...] = (
         "raw_records_sipm",
-        "raw_records_ext",  
+        "raw_records_ext",
         "raw_records", # raw_records has to be last due to lineage
     )
 
@@ -126,6 +55,67 @@ class DAQReader(strax.Plugin):
     __version__ = "0.1.0"
     input_timeout = 300
 
+    # All these must have track=False, so the raw_records hash never changes.
+    # DAQ settings should match settings given to redax.
+    record_length = amstrax.XAMSConfig(
+        default=110, track=False, type=int, help="Number of samples per raw_record"
+    )
+    max_digitizer_sampling_time = amstrax.XAMSConfig(
+        default=10,
+        track=False,
+        type=int,
+        help="Highest interval time of the digitizer sampling times(s) used.",
+    )
+    run_start_time = amstrax.XAMSConfig(
+        type=float,
+        track=False,
+        default=0,
+        help="time of start run (s since unix epoch)",
+    )
+    daq_chunk_duration = amstrax.XAMSConfig(
+        track=False,
+        default=int(5e9),
+        type=int,
+        help="Duration of regular chunks in ns",
+    )
+    daq_overlap_chunk_duration = amstrax.XAMSConfig(
+        track=False,
+        default=int(5e8),
+        type=int,
+        help="Duration of intermediate/overlap chunks in ns",
+    )
+    daq_compressor = amstrax.XAMSConfig(
+        default="lz4",
+        track=False,
+        help="Algorithm used for (de)compressing the live data",
+    )
+    readout_threads = amstrax.XAMSConfig(
+        type=dict,
+        track=False,
+        help=(
+            "Dictionary of the readout threads where the keys "
+            "specify the reader and value the number of threads"
+        ),
+    )
+    daq_input_dir = amstrax.XAMSConfig(
+        type=str, track=False, help="Directory where readers put data")
+    safe_break_in_pulses = amstrax.XAMSConfig(
+        default=1000,
+        track=False,
+        infer_type=False,
+        help=(
+            "Time (ns) between pulses indicating a safe break "
+            "in the datastream -- gaps of this size cannot be "
+            "interior to peaklets."
+        ),
+    )
+    channel_map = amstrax.XAMSConfig(
+        default="rundoc://?path=xams_bookkeeping.channel_map&fallback=xams_default",
+        track=False,
+        type=immutabledict,
+        infer_type=False,
+        help="immutabledict mapping subdetector to (min, max), loaded from rundoc",
+    )
 
 
     def infer_dtype(self):
@@ -230,7 +220,7 @@ class DAQReader(strax.Plugin):
             # Records are sorted by (start)time and are of variable length.
             # Their end-times can differ. In the most pessimistic case we have
             # to look back one record length for each channel.
-            tot_channels = np.sum([np.diff(x) + 1 for x in self.config["channel_map"].values()])
+            tot_channels = np.sum([np.diff(x) + 1 for x in self.channel_map.values()])
             look_n_samples = self.config["record_length"] * tot_channels
             last_end = strax.endtime(records[-look_n_samples:]).max()
             if first_start < start or last_start >= end:
@@ -351,20 +341,20 @@ class DAQReader(strax.Plugin):
 
 
         # Split records by channel
-        tpc_min = min(self.config['channel_map']['bottom'][0], self.config['channel_map']['top'][0])
-        tpc_max = max(self.config['channel_map']['bottom'][1], self.config['channel_map']['top'][1])
+        tpc_min = min(self.channel_map['bottom'][0], self.channel_map['top'][0])
+        tpc_max = max(self.channel_map['bottom'][1], self.channel_map['top'][1])
 
         channel_ranges = {
             'tpc': (tpc_min, tpc_max),
         }
 
-        if 'external' in self.config['channel_map']:
-            channel_ranges['external'] = self.config['channel_map']['external']
+        if 'external' in self.channel_map:
+            channel_ranges['external'] = self.channel_map['external']
         else:
             channel_ranges['external'] = (-1, -1)
 
-        if 'sipm' in self.config['channel_map']:
-            channel_ranges['sipm'] = self.config['channel_map']['sipm']
+        if 'sipm' in self.channel_map:
+            channel_ranges['sipm'] = self.channel_map['sipm']
         else:
             channel_ranges['sipm'] = (-2, -2)
 

--- a/amstrax/plugins/raw_records/daqreader.py
+++ b/amstrax/plugins/raw_records/daqreader.py
@@ -72,16 +72,6 @@ class ArtificialDeadtimeInserted(UserWarning):
             "specify the reader and value the number of threads"
         ),
     ),
-    strax.Option(
-        "channels_polarity",
-        type=dict,
-        track=False,
-        default=immutabledict({}),
-        help=(
-            "Dictionary of the channels where the keys specify "
-            "the channel and value the polarity of the channel"
-        ),
-    ),
     strax.Option("daq_input_dir", type=str, track=False, help="Directory where readers put data"),
     # DAQReader settings
     strax.Option(
@@ -133,7 +123,7 @@ class DAQReader(strax.Plugin):
         raw_records_sipm=False,
     )
     compressor = "lz4"
-    __version__ = "0.0.0"
+    __version__ = "0.1.0"
     input_timeout = 300
 
 
@@ -360,14 +350,6 @@ class DAQReader(strax.Plugin):
             print(f"\tChannel {channel} has {count} records")        
 
 
-        for channel, polarity in self.config["channels_polarity"].items():
-            if polarity == 1:
-                # This means that the polarity of this channel is positive
-                # most likely a SiPM channel
-                # usually we work with PMTs with negative polarity
-                # so for convenience we invert the polarity here
-                records["data"][records["channel"] == channel] *= -1
-    
         # Split records by channel
         tpc_min = min(self.config['channel_map']['bottom'][0], self.config['channel_map']['top'][0])
         tpc_max = max(self.config['channel_map']['bottom'][1], self.config['channel_map']['top'][1])

--- a/amstrax/plugins/records/pulse_processing.py
+++ b/amstrax/plugins/records/pulse_processing.py
@@ -9,8 +9,7 @@ export, __all__ = strax.exporter()
 __all__ += ['NO_PULSE_COUNTS']
 
 HITFINDER_OPTIONS = tuple([
-    strax.Option(
-        'hit_min_amplitude',
+    amstrax.XAMSConfig(
         default='xams_thresholds',
         help='Minimum hit amplitude in ADC counts above baseline. '
              'See amstrax.hit_min_amplitude in hitfinder_thresholds.py for options.'
@@ -18,35 +17,6 @@ HITFINDER_OPTIONS = tuple([
 
 
 @export
-@strax.takes_config(
-    strax.Option(
-        'baseline_samples',
-        default=20, infer_type=False,
-        help='Number of samples to use at the start of the pulse to determine '
-             'the baseline'),
-    # PMT pulse processing options
-    strax.Option(
-        'pmt_pulse_filter',
-        default=None, infer_type=False,
-        help='Linear filter to apply to pulses, will be normalized.'),   
-    strax.Option(
-        'save_outside_hits',
-        default=(3, 20), infer_type=False,
-        help='Save (left, right) samples besides hits; cut the rest'),
-    strax.Option(
-        'n_tpc_pmts', type=int,
-        help='Number of TPC channels'),
-    strax.Option(
-        'check_raw_record_overlaps',
-        default=True, track=False, infer_type=False,
-        help='Crash if any of the pulses in raw_records overlap with others '
-             'in the same channel'),
-    strax.Option(
-        'allow_sloppy_chunking',
-        default=True, track=False, infer_type=False,
-        help=('Use a default baseline for incorrectly chunked fragments. '
-              'This is a kludge for improperly converted XENON1T data.')),
-    *HITFINDER_OPTIONS)
 class PulseProcessing(strax.Plugin):
     """
     Get the specific raw_records of the measurements 
@@ -67,6 +37,31 @@ class PulseProcessing(strax.Plugin):
     baseline rms channel.
     """
     __version__ = '0.3.0'
+    baseline_samples = amstrax.XAMSConfig(
+        default=20,
+        infer_type=False,
+        help='Number of samples to use at the start of the pulse to determine the baseline')
+    pmt_pulse_filter = amstrax.XAMSConfig(
+        default=None,
+        infer_type=False,
+        help='Linear filter to apply to pulses, will be normalized.')
+    save_outside_hits = amstrax.XAMSConfig(
+        default=(3, 20),
+        infer_type=False,
+        help='Save (left, right) samples besides hits; cut the rest')
+    n_tpc_pmts = amstrax.XAMSConfig(type=int, help='Number of TPC channels')
+    check_raw_record_overlaps = amstrax.XAMSConfig(
+        default=True,
+        track=False,
+        infer_type=False,
+        help='Crash if any of the pulses in raw_records overlap with others in the same channel')
+    allow_sloppy_chunking = amstrax.XAMSConfig(
+        default=True,
+        track=False,
+        infer_type=False,
+        help=('Use a default baseline for incorrectly chunked fragments. '
+              'This is a kludge for improperly converted XENON1T data.'))
+    hit_min_amplitude = HITFINDER_OPTIONS[0]
     
     parallel = 'process'
     rechunk_on_save = immutabledict(

--- a/amstrax/plugins/records_ext/pulse_processing_ext.py
+++ b/amstrax/plugins/records_ext/pulse_processing_ext.py
@@ -1,3 +1,4 @@
+import amstrax
 import numba
 import numpy as np
 import strax
@@ -6,13 +7,6 @@ from immutabledict import immutabledict
 export, __all__ = strax.exporter()
 
 @export
-@strax.takes_config(
-    strax.Option(
-        'baseline_samples',
-        default=20, infer_type=False,
-        help='Number of samples to use at the start of the pulse to determine '
-             'the baseline'),
-)
 class PulseProcessingEXT(strax.Plugin):
     """
     Plugin which performs the pulse processing steps:
@@ -23,6 +17,11 @@ class PulseProcessingEXT(strax.Plugin):
     5. Pulse length and area calculation
 
     """
+    baseline_samples = amstrax.XAMSConfig(
+        default=20, infer_type=False,
+        help='Number of samples to use at the start of the pulse to determine '
+             'the baseline')
+
     __version__ = '0.0.1'
     
     parallel = 'process'

--- a/amstrax/plugins/records_ext/pulse_processing_sipm.py
+++ b/amstrax/plugins/records_ext/pulse_processing_sipm.py
@@ -23,7 +23,7 @@ class PulseProcessingSiPM(strax.Plugin):
     5. Pulse length and area calculation
 
     """
-    __version__ = '0.0.1'
+    __version__ = '0.0.2'
     
     parallel = 'process'
     rechunk_on_save = False
@@ -53,7 +53,7 @@ class PulseProcessingSiPM(strax.Plugin):
 
         r = strax.sort_by_time(r)
         strax.zero_out_of_bounds(r)
-        strax.baseline(r, baseline_samples=self.baseline_samples, flip=True)
+        strax.baseline(r, baseline_samples=self.baseline_samples, flip=False)
 
         strax.integrate(r)
 

--- a/amstrax/plugins/records_ext/pulse_processing_sipm.py
+++ b/amstrax/plugins/records_ext/pulse_processing_sipm.py
@@ -1,3 +1,4 @@
+import amstrax
 import numba
 import numpy as np
 import strax
@@ -6,13 +7,6 @@ from immutabledict import immutabledict
 export, __all__ = strax.exporter()
 
 @export
-@strax.takes_config(
-    strax.Option(
-        'baseline_samples',
-        default=20, infer_type=False,
-        help='Number of samples to use at the start of the SiPM pulse to determine '
-             'the baseline'),
-)
 class PulseProcessingSiPM(strax.Plugin):
     """
     Plugin which performs the pulse processing steps:
@@ -23,6 +17,11 @@ class PulseProcessingSiPM(strax.Plugin):
     5. Pulse length and area calculation
 
     """
+    baseline_samples = amstrax.XAMSConfig(
+        default=20, infer_type=False,
+        help='Number of samples to use at the start of the SiPM pulse to determine '
+             'the baseline')
+
     __version__ = '0.0.2'
     
     parallel = 'process'

--- a/amstrax/xams_config.py
+++ b/amstrax/xams_config.py
@@ -134,6 +134,8 @@ class XAMSConfig(Config):
         if value is None:
             if fallback == "xams_default":
                 return DEFAULT_CHANNEL_MAP
+            if fallback == "empty":
+                return []
             raise ValueError(f"No rundoc value found for path '{path}' and run {plugin.run_id}")
         return _as_immutabledict_channel_map(value)
 

--- a/amstrax/xams_config.py
+++ b/amstrax/xams_config.py
@@ -36,33 +36,35 @@ class XAMSConfig(Config):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self._cached_value = None  # Initialize cache for the fetched value
+        self._cache = {}
 
     def fetch(self, plugin):
         """
         Overrides the fetch method to load corrections from JSON or CMT files.
         Handles both 'cmt://' and 'file://' URLs. Otherwise, returns default.
         """
-
-        # Check if the value has already been cached
-        if self._cached_value is not None:
-            return self._cached_value
-
         config_value = plugin.config.get(self.name, self.default)
+        run_id = getattr(plugin, "run_id", None)
 
         # Check if the config is a cmt URL or file URL
         if isinstance(config_value, str):
-            if config_value.startswith("cmt://"):
-                self._cached_value = self._fetch_from_cmt(plugin, config_value)
-            elif config_value.startswith("file://"):
-                self._cached_value = self._fetch_from_file_url(plugin, config_value)
-            elif config_value.startswith("rundoc://"):
-                self._cached_value = self._fetch_from_rundoc_url(plugin, config_value)
-        else:
-            # Cache the default value if no URL is provided
-            self._cached_value = config_value
+            cache_key = (config_value, str(run_id))
+            if cache_key in self._cache:
+                return self._cache[cache_key]
 
-        return self._cached_value
+            if config_value.startswith("cmt://"):
+                value = self._fetch_from_cmt(plugin, config_value)
+            elif config_value.startswith("file://"):
+                value = self._fetch_from_file_url(plugin, config_value)
+            elif config_value.startswith("rundoc://"):
+                value = self._fetch_from_rundoc_url(plugin, config_value)
+            else:
+                value = config_value
+
+            self._cache[cache_key] = value
+            return value
+
+        return config_value
 
     def _fetch_from_cmt(self, plugin, config_value):
         """Fetch correction from a cmt:// URL."""
@@ -89,7 +91,7 @@ class XAMSConfig(Config):
         # Load the correction data (e.g., {'001200': 5500, '001300': 6000})
         correction_data = amstrax.get_correction(correction_file, branch=github_branch)
 
-        value = self.find_correction_value(correction_data, run_id)
+        value = self.find_correction_value(correction_data, run_id, correction_file=correction_file)
 
         return value
 
@@ -103,8 +105,6 @@ class XAMSConfig(Config):
 
         github_branch = query_params.get("github_branch", ["master"])[0]
 
-        self.filename = filename
-
         if not filename:
             raise ValueError(f"Invalid file:// URL, missing filename: {config_value}")
 
@@ -112,7 +112,7 @@ class XAMSConfig(Config):
         correction_data = amstrax.get_correction(filename, branch=github_branch)
 
         # Find the correction value based on the run_id
-        value = self.find_correction_value(correction_data, run_id)
+        value = self.find_correction_value(correction_data, run_id, correction_file=filename)
 
         return value
 
@@ -137,8 +137,8 @@ class XAMSConfig(Config):
             raise ValueError(f"No rundoc value found for path '{path}' and run {plugin.run_id}")
         return _as_immutabledict_channel_map(value)
 
-    def find_correction_value(self, correction_data, run_id):
-        run_id = run_id.zfill(6)  # Ensure run_id is always 6 digits
+    def find_correction_value(self, correction_data, run_id, correction_file=None):
+        run_id = str(run_id).zfill(6)  # Ensure run_id is always 6 digits
         value = None
 
         for run_range in correction_data.keys():
@@ -148,14 +148,14 @@ class XAMSConfig(Config):
                 if end_run == "*":
                     # Only allow * for online corrections
                     # check if there is _dev in the filename
-                    if "_dev" not in self.filename:
+                    if "_dev" not in str(correction_file):
                         raise ValueError(f"Wildcard '*' is only allowed for online corrections")
                     end_run = "999999"  # Treat * as the highest possible run ID
 
                 if start_run == "*":
                     # Only allow * for online corrections
                     # check if there is _dev in the filename
-                    if "_dev" not in self.filename:
+                    if "_dev" not in str(correction_file):
                         raise ValueError(f"Wildcard '*' is only allowed for online corrections")
                     start_run = "000000"
 

--- a/tests/test_corrections.py
+++ b/tests/test_corrections.py
@@ -1,4 +1,6 @@
 import unittest
+from types import SimpleNamespace
+
 import amstrax
 import strax
 
@@ -37,6 +39,52 @@ class TestXamsCorrections(unittest.TestCase):
         # Check that the test2 config works and fetches the correct value
         print(f"Test2 config value: {test2_value}")
         self.assertIsNotNone(test2_value, "Test2 config should not be None")
+
+
+class TestXAMSConfigCaching(unittest.TestCase):
+    def test_rundoc_config_cache_is_run_aware(self):
+        """
+        Rundoc-backed config values must not be reused across run IDs.
+        """
+        cfg = amstrax.XAMSConfig(
+            name="channel_map",
+            default="rundoc://?path=daq_config.channel_map",
+        )
+        calls = []
+        original = amstrax.xams_config.get_rundoc_value
+
+        def fake_get_rundoc_value(run_id, path, detector="xams", default=None):
+            calls.append((str(run_id), path, detector))
+            value = int(run_id)
+            return {"bottom": [value, value], "top": [value + 1, value + 1]}
+
+        try:
+            amstrax.xams_config.get_rundoc_value = fake_get_rundoc_value
+            run_1 = SimpleNamespace(run_id="1", config={})
+            run_2 = SimpleNamespace(run_id="2", config={})
+
+            self.assertEqual(cfg.fetch(run_1)["bottom"], (1, 1))
+            self.assertEqual(cfg.fetch(run_2)["bottom"], (2, 2))
+            self.assertEqual(cfg.fetch(run_1)["bottom"], (1, 1))
+            self.assertEqual(calls, [
+                ("1", "daq_config.channel_map", "xams"),
+                ("2", "daq_config.channel_map", "xams"),
+            ])
+        finally:
+            amstrax.xams_config.get_rundoc_value = original
+
+    def test_online_wildcard_correction_does_not_require_mutable_filename_state(self):
+        cfg = amstrax.XAMSConfig(default=1)
+        correction_data = {"1-*": 42}
+
+        self.assertEqual(
+            cfg.find_correction_value(
+                correction_data,
+                "2",
+                correction_file="example_dev.json",
+            ),
+            42,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_corrections.py
+++ b/tests/test_corrections.py
@@ -47,7 +47,6 @@ class TestXAMSConfigCaching(unittest.TestCase):
         Rundoc-backed config values must not be reused across run IDs.
         """
         cfg = amstrax.XAMSConfig(
-            name="channel_map",
             default="rundoc://?path=daq_config.channel_map",
         )
         calls = []


### PR DESCRIPTION
This pull request introduces significant improvements to the configuration system for plugins in the `amstrax` package, standardizing the use of the `XAMSConfig` descriptor for plugin configuration options. It also refactors the DAQ channel polarity extraction logic into a new dedicated module, and makes several related codebase cleanups and enhancements.

Key changes include:

**Configuration System Modernization:**

- Replaces the use of `strax.takes_config` and `strax.Option` with the `XAMSConfig` descriptor for plugin configuration in multiple plugins including `EventBasics`, `EventPositions`, `EventCoincidences`, `Events`, `LEDCalibration`, `RecordsLED`, and `EventAreaPerChannel`. This makes configuration more consistent, discoverable, and easier to maintain. [[1]](diffhunk://#diff-cb13d0d10cb9da06a26838aa6e452354e34b1e9d0d080c3a75288d528ca608c5L9-L30) [[2]](diffhunk://#diff-cb13d0d10cb9da06a26838aa6e452354e34b1e9d0d080c3a75288d528ca608c5R23-R47) [[3]](diffhunk://#diff-0054fdf22112a4f98fa8364943ce06408beaa1b0b4c3351c0a83b0d63ea1f1c6L13-L27) [[4]](diffhunk://#diff-0054fdf22112a4f98fa8364943ce06408beaa1b0b4c3351c0a83b0d63ea1f1c6R26-R37) [[5]](diffhunk://#diff-07c18b3cd788ae9bbca76c3e698fc0f719508767c0367fc376fcd5f0abe8632bL10-R24) [[6]](diffhunk://#diff-aac0c98f1a8af8496d416e0e3c2b921f119b4bd062ed7a8a2f48ac244f5a115aR1-R18) [[7]](diffhunk://#diff-d18737499a66460e9e66a305779a48ded39e5325d0369db573c0bdbf7ba21f67R1) [[8]](diffhunk://#diff-d18737499a66460e9e66a305779a48ded39e5325d0369db573c0bdbf7ba21f67L10-L19) [[9]](diffhunk://#diff-d18737499a66460e9e66a305779a48ded39e5325d0369db573c0bdbf7ba21f67R25-R31) [[10]](diffhunk://#diff-149310e8a0b58ff3f0c2970cbf6aa0295d9134dae2041b6145dfc273bbe92aeeL1-R39) [[11]](diffhunk://#diff-32730f845beebea238b09afe741bcb6545a05623840fe33e2197eb5dea7847a5L10-L20)
- Removes now-unnecessary `setup` methods that previously copied config values to instance attributes, further simplifying plugin code. [[1]](diffhunk://#diff-cb13d0d10cb9da06a26838aa6e452354e34b1e9d0d080c3a75288d528ca608c5L118-L125) [[2]](diffhunk://#diff-0054fdf22112a4f98fa8364943ce06408beaa1b0b4c3351c0a83b0d63ea1f1c6L57-L63) [[3]](diffhunk://#diff-d18737499a66460e9e66a305779a48ded39e5325d0369db573c0bdbf7ba21f67L53-L56)

**DAQ Configuration Refactoring:**

- Moves the channel polarity extraction logic from `contexts.py` into a new module `daq_config.py`, and exposes it as `extract_channel_polarity`. This function is now more robust, supporting different input types and improved error handling. [[1]](diffhunk://#diff-c6fbe76a1e4be0f3cfad4b0a4033bc62c81b97608c0c36e2a6a6943aeaf73dbbR13-R15) [[2]](diffhunk://#diff-40bc6493773ab4da5a36122d89e32a930849309e776a60fae25d47cea781f59bR1-R54) [[3]](diffhunk://#diff-cde104ae718323a16ab2369427557e051dd43ad6bc3f7541ceb79de1cba2aea3L209-R208)
- Updates the DAQ reader context and config-building logic to use the new function, removing the direct handling of channel polarity maps from the context logic. [[1]](diffhunk://#diff-cde104ae718323a16ab2369427557e051dd43ad6bc3f7541ceb79de1cba2aea3L158-R160) [[2]](diffhunk://#diff-cde104ae718323a16ab2369427557e051dd43ad6bc3f7541ceb79de1cba2aea3L239-R223)

**Other Improvements and Cleanups:**

- Updates context and plugin dependencies to reflect new data products and configuration options, such as including `raw_records_sipm` in relevant places. [[1]](diffhunk://#diff-cde104ae718323a16ab2369427557e051dd43ad6bc3f7541ceb79de1cba2aea3L239-R223) [[2]](diffhunk://#diff-149310e8a0b58ff3f0c2970cbf6aa0295d9134dae2041b6145dfc273bbe92aeeL1-R39)
- Fixes the evaluation of gain models in `mini_analysis.py` to use `amstrax.XAMSConfig` for consistency.
- Minor code cleanups, such as removing redundant blank lines and unused imports. [[1]](diffhunk://#diff-cb13d0d10cb9da06a26838aa6e452354e34b1e9d0d080c3a75288d528ca608c5L382) [[2]](diffhunk://#diff-149310e8a0b58ff3f0c2970cbf6aa0295d9134dae2041b6145dfc273bbe92aeeL1-R39)

These changes collectively modernize the configuration approach, improve code modularity, and pave the way for easier extension and maintenance.

**References:**
- [[1]](diffhunk://#diff-cb13d0d10cb9da06a26838aa6e452354e34b1e9d0d080c3a75288d528ca608c5L9-L30) [[2]](diffhunk://#diff-cb13d0d10cb9da06a26838aa6e452354e34b1e9d0d080c3a75288d528ca608c5R23-R47) [[3]](diffhunk://#diff-cb13d0d10cb9da06a26838aa6e452354e34b1e9d0d080c3a75288d528ca608c5L118-L125) [[4]](diffhunk://#diff-cb13d0d10cb9da06a26838aa6e452354e34b1e9d0d080c3a75288d528ca608c5L382)
- [[1]](diffhunk://#diff-0054fdf22112a4f98fa8364943ce06408beaa1b0b4c3351c0a83b0d63ea1f1c6L13-L27) [[2]](diffhunk://#diff-0054fdf22112a4f98fa8364943ce06408beaa1b0b4c3351c0a83b0d63ea1f1c6R26-R37) [[3]](diffhunk://#diff-0054fdf22112a4f98fa8364943ce06408beaa1b0b4c3351c0a83b0d63ea1f1c6L57-L63)
- [amstrax/plugins/events/event_coincidences.pyL10-R24](diffhunk://#diff-07c18b3cd788ae9bbca76c3e698fc0f719508767c0367fc376fcd5f0abe8632bL10-R24)
- [[1]](diffhunk://#diff-aac0c98f1a8af8496d416e0e3c2b921f119b4bd062ed7a8a2f48ac244f5a115aR1-R18) [[2]](diffhunk://#diff-aac0c98f1a8af8496d416e0e3c2b921f119b4bd062ed7a8a2f48ac244f5a115aL70)
- [[1]](diffhunk://#diff-d18737499a66460e9e66a305779a48ded39e5325d0369db573c0bdbf7ba21f67R1) [[2]](diffhunk://#diff-d18737499a66460e9e66a305779a48ded39e5325d0369db573c0bdbf7ba21f67L10-L19) [[3]](diffhunk://#diff-d18737499a66460e9e66a305779a48ded39e5325d0369db573c0bdbf7ba21f67R25-R31) [[4]](diffhunk://#diff-d18737499a66460e9e66a305779a48ded39e5325d0369db573c0bdbf7ba21f67L53-L56)
- [amstrax/plugins/led_calibration/records_led.pyL1-R39](diffhunk://#diff-149310e8a0b58ff3f0c2970cbf6aa0295d9134dae2041b6145dfc273bbe92aeeL1-R39)
- [amstrax/plugins/events/event_area_per_channel.pyL10-L20](diffhunk://#diff-32730f845beebea238b09afe741bcb6545a05623840fe33e2197eb5dea7847a5L10-L20)
- [[1]](diffhunk://#diff-c6fbe76a1e4be0f3cfad4b0a4033bc62c81b97608c0c36e2a6a6943aeaf73dbbR13-R15) [[2]](diffhunk://#diff-40bc6493773ab4da5a36122d89e32a930849309e776a60fae25d47cea781f59bR1-R54) [[3]](diffhunk://#diff-cde104ae718323a16ab2369427557e051dd43ad6bc3f7541ceb79de1cba2aea3L158-R160) [[4]](diffhunk://#diff-cde104ae718323a16ab2369427557e051dd43ad6bc3f7541ceb79de1cba2aea3L209-R208) [[5]](diffhunk://#diff-cde104ae718323a16ab2369427557e051dd43ad6bc3f7541ceb79de1cba2aea3L239-R223)
- [amstrax/mini_analysis.pyL63-R63](diffhunk://#diff-68d272d69ade17991be128e381dc285233cf0b78ef3f146e22fe8da4dd2e93d1L63-R63)